### PR TITLE
Revamp landing page to mirror Room Guide layout

### DIFF
--- a/public/scripts/filters.js
+++ b/public/scripts/filters.js
@@ -2,6 +2,7 @@
   const areaFilter = document.getElementById('area-filter');
   const categoryFilter = document.getElementById('category-filter');
   const cards = document.querySelectorAll('[data-grid] .shop-card');
+  const searchButton = document.getElementById('search-button');
 
   function applyFilters() {
     const areaValue = areaFilter ? areaFilter.value : 'all';
@@ -21,5 +22,15 @@
 
   if (categoryFilter) {
     categoryFilter.addEventListener('change', applyFilters);
+  }
+
+  if (searchButton) {
+    searchButton.addEventListener('click', () => {
+      applyFilters();
+      const grid = document.querySelector('[data-grid]');
+      if (grid) {
+        grid.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+    });
   }
 })();

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -1,11 +1,13 @@
 :root {
-  --color-bg: #0f0f13;
-  --color-surface: #18181f;
-  --color-primary: #ff4b91;
-  --color-secondary: #8f58ff;
-  --color-text: #f5f5f7;
-  --color-muted: #a1a1b5;
-  --max-width: 1080px;
+  --color-bg: #07090f;
+  --color-surface: #0f1119;
+  --color-panel: #141724;
+  --color-primary: #ff496a;
+  --color-accent: #4f8cff;
+  --color-text: #f6f7fb;
+  --color-muted: #a3a9c2;
+  --color-border: rgba(255, 255, 255, 0.08);
+  --max-width: 1120px;
   font-family: 'Pretendard', -apple-system, BlinkMacSystemFont, 'Segoe UI',
     'Noto Sans KR', sans-serif;
 }
@@ -16,9 +18,9 @@
 
 body {
   margin: 0;
-  background: radial-gradient(circle at top left, #1c1c27, #0b0b0f 60%);
+  background: radial-gradient(circle at top left, #15203a, var(--color-bg) 60%);
   color: var(--color-text);
-  line-height: 1.5;
+  line-height: 1.6;
 }
 
 a {
@@ -31,155 +33,319 @@ a:focus {
   color: var(--color-primary);
 }
 
+img {
+  max-width: 100%;
+  display: block;
+}
+
 .container {
   width: min(100%, var(--max-width));
   margin: 0 auto;
   padding: 0 1.5rem;
 }
 
-.container--small {
-  max-width: 640px;
-}
-
 .site-header {
-  background: rgba(15, 15, 19, 0.8);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-  backdrop-filter: blur(12px);
   position: sticky;
   top: 0;
   z-index: 100;
+  background: rgba(7, 9, 15, 0.92);
+  backdrop-filter: blur(16px);
+  border-bottom: 1px solid var(--color-border);
 }
 
-.site-header .container {
+.site-header__topbar {
+  border-bottom: 1px solid var(--color-border);
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+.site-header__topbar .container {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1rem 1.5rem;
+  padding: 0.6rem 1.5rem;
+}
+
+.topbar__links {
+  display: flex;
+  gap: 1.5rem;
+}
+
+.site-header__main {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+  padding: 1.2rem 1.5rem;
 }
 
 .branding {
-  font-size: 1.3rem;
+  font-size: 1.4rem;
   font-weight: 700;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
 }
 
-.nav a {
-  margin-left: 1rem;
+.nav {
+  display: flex;
+  gap: 1.5rem;
   font-weight: 500;
   color: var(--color-muted);
 }
 
-.nav a:hover {
-  color: var(--color-primary);
+.header-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.65rem 1.4rem;
+  border-radius: 999px;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn--primary {
+  background: linear-gradient(135deg, var(--color-primary), #ff7c4d);
+  color: #fff;
+  box-shadow: 0 10px 20px rgba(255, 73, 106, 0.25);
+}
+
+.btn--ghost {
+  border: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--color-muted);
+}
+
+.btn--large {
+  padding: 0.85rem 2.4rem;
+  font-size: 1rem;
+}
+
+.btn:hover {
+  transform: translateY(-2px);
 }
 
 .hero {
+  position: relative;
   padding: 6rem 0 4rem;
-  background: linear-gradient(160deg, rgba(255, 75, 145, 0.24), rgba(143, 88, 255, 0.18));
+  overflow: hidden;
 }
 
-.hero__content h1 {
-  font-size: clamp(2rem, 3vw + 1rem, 3.6rem);
-  margin-bottom: 1rem;
+.hero__overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(140deg, rgba(32, 44, 78, 0.8), rgba(7, 9, 15, 0.95));
+  mix-blend-mode: lighten;
+  pointer-events: none;
 }
 
-.hero__content p {
-  max-width: 540px;
+.hero__container {
+  position: relative;
+  display: grid;
+  gap: 3rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  align-items: center;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 1rem;
+  border-radius: 999px;
+  background: rgba(79, 140, 255, 0.18);
+  color: #9cc1ff;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.hero__text h1 {
+  font-size: clamp(2.2rem, 3vw + 1.5rem, 3.6rem);
+  margin: 1rem 0;
+  line-height: 1.2;
+}
+
+.hero__text p {
   color: var(--color-muted);
+  max-width: 520px;
   margin-bottom: 2rem;
+}
+
+.hero__search {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  margin-bottom: 1.5rem;
 }
 
 .hero__filters {
   display: flex;
-  gap: 1.5rem;
+  gap: 1rem;
   flex-wrap: wrap;
 }
 
-.filter-group {
+.input-group {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-}
-
-.filter-group label {
-  font-weight: 600;
+  min-width: 160px;
   color: var(--color-muted);
+  font-weight: 500;
 }
 
-.filter-group select {
+.input-group select {
   padding: 0.75rem 1rem;
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  background: rgba(15, 15, 19, 0.6);
+  border-radius: 14px;
+  border: 1px solid var(--color-border);
+  background: rgba(15, 17, 25, 0.8);
   color: var(--color-text);
-  min-width: 180px;
+}
+
+.hero__highlights {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+  padding: 0;
+  margin: 0;
+  color: var(--color-muted);
+  flex-wrap: wrap;
+  font-size: 0.95rem;
+}
+
+.hero__highlights li::before {
+  content: '•';
+  margin-right: 0.5rem;
+  color: var(--color-primary);
+}
+
+.hero__stats {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.stat-card {
+  background: rgba(15, 17, 25, 0.8);
+  padding: 1.5rem;
+  border-radius: 18px;
+  border: 1px solid var(--color-border);
+  backdrop-filter: blur(8px);
+}
+
+.stat-card__number {
+  display: block;
+  font-size: 2rem;
+  font-weight: 700;
+}
+
+.stat-card__label {
+  color: var(--color-muted);
+  font-size: 0.95rem;
 }
 
 .section {
-  padding: 4rem 0;
+  padding: 4.5rem 0;
 }
 
-.section--center {
-  text-align: center;
+.section--intro {
+  background: rgba(15, 17, 25, 0.4);
+  border-top: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border);
 }
 
-.section h2 {
+.section__container {
+  display: grid;
+  gap: 2.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: start;
+}
+
+.section__title {
   font-size: 2rem;
-  margin-bottom: 1.5rem;
+  margin: 0 0 1rem;
 }
 
-.section__hint {
+.section__subtitle {
   color: var(--color-muted);
-  font-size: 0.95rem;
+  margin: 0;
+  max-width: 520px;
+}
+
+.feature-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.feature-card {
+  background: rgba(7, 9, 15, 0.75);
+  padding: 1.75rem;
+  border-radius: 18px;
+  border: 1px solid var(--color-border);
+}
+
+.feature-card h3 {
+  margin-top: 0;
+}
+
+.section__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 2rem;
+  flex-wrap: wrap;
+  margin-bottom: 2.5rem;
 }
 
 .shop-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 1.75rem;
+  gap: 1.8rem;
 }
 
 .shop-card {
-  background: var(--color-surface);
-  border-radius: 18px;
+  background: rgba(15, 17, 25, 0.8);
+  border-radius: 20px;
   overflow: hidden;
+  border: 1px solid var(--color-border);
   display: flex;
   flex-direction: column;
-  border: 1px solid rgba(255, 255, 255, 0.05);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .shop-card:hover {
   transform: translateY(-6px);
-  box-shadow: 0 18px 28px rgba(0, 0, 0, 0.25);
+  box-shadow: 0 20px 36px rgba(0, 0, 0, 0.35);
 }
 
 .shop-card__image img {
   width: 100%;
   height: 180px;
   object-fit: cover;
-  display: block;
 }
 
 .shop-card__body {
-  padding: 1.5rem;
+  padding: 1.6rem;
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
 }
 
-.shop-card__area {
+.shop-card__meta {
   color: var(--color-muted);
   font-size: 0.9rem;
 }
 
-.shop-card__title {
+.shop-card__body h3 {
   margin: 0;
   font-size: 1.3rem;
 }
 
-.shop-card__desc {
+.shop-card__body p {
   margin: 0;
   color: var(--color-muted);
 }
@@ -188,20 +354,6 @@ a:focus {
   margin-top: auto;
   font-weight: 600;
   color: var(--color-primary);
-}
-
-.category-list {
-  display: flex;
-  gap: 0.75rem;
-  flex-wrap: wrap;
-}
-
-.category-pill {
-  padding: 0.5rem 1rem;
-  border-radius: 999px;
-  background: rgba(255, 75, 145, 0.16);
-  color: var(--color-primary);
-  font-weight: 600;
 }
 
 .detail-hero {
@@ -218,7 +370,7 @@ a:focus {
 .detail-hero__image img {
   width: 100%;
   border-radius: 24px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--color-border);
 }
 
 .detail-hero__meta {
@@ -257,9 +409,9 @@ a:focus {
 
 .highlight-list li {
   padding: 1rem 1.25rem;
-  background: rgba(24, 24, 31, 0.8);
+  background: rgba(15, 17, 25, 0.75);
   border-radius: 14px;
-  border: 1px solid rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--color-border);
 }
 
 .back-link {
@@ -270,30 +422,130 @@ a:focus {
   font-weight: 600;
 }
 
+.section--muted {
+  background: rgba(15, 17, 25, 0.55);
+}
+
+.category-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.category-chip {
+  padding: 0.6rem 1.2rem;
+  border-radius: 999px;
+  background: rgba(79, 140, 255, 0.16);
+  color: #a9c8ff;
+  font-weight: 600;
+}
+
+.step-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.75rem;
+}
+
+.step-card {
+  background: rgba(15, 17, 25, 0.75);
+  border-radius: 20px;
+  padding: 2rem 1.75rem;
+  border: 1px solid var(--color-border);
+}
+
+.step-card__number {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--color-accent);
+}
+
+.section--cta {
+  background: linear-gradient(135deg, rgba(255, 73, 106, 0.25), rgba(79, 140, 255, 0.25));
+  border-top: 1px solid var(--color-border);
+}
+
+.section--cta__content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 2rem;
+}
+
 .site-footer {
-  border-top: 1px solid rgba(255, 255, 255, 0.06);
-  padding: 2rem 0;
-  background: rgba(15, 15, 19, 0.85);
+  background: rgba(7, 9, 15, 0.95);
+  border-top: 1px solid var(--color-border);
   margin-top: 4rem;
 }
 
-.site-footer p {
+.site-footer__content {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  padding: 3rem 1.5rem;
+}
+
+.site-footer h3,
+.site-footer h4 {
+  margin-top: 0;
+}
+
+.site-footer p,
+.site-footer li {
+  color: var(--color-muted);
   margin: 0;
+  list-style: none;
+}
+
+.site-footer ul {
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.site-footer__bottom {
+  border-top: 1px solid var(--color-border);
+  text-align: center;
+  padding: 1.2rem 1.5rem;
   color: var(--color-muted);
   font-size: 0.9rem;
 }
 
-@media (max-width: 640px) {
-  .site-header .nav {
-    display: none;
+@media (max-width: 768px) {
+  .site-header__main {
+    flex-direction: column;
+    align-items: flex-start;
   }
 
+  .nav {
+    order: 3;
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+
+  .header-actions {
+    order: 2;
+  }
+
+  .hero {
+    padding-top: 5rem;
+  }
+}
+
+@media (max-width: 540px) {
   .hero__filters {
-    flex-direction: column;
+    width: 100%;
+  }
+
+  .input-group {
+    width: 100%;
+  }
+
+  .hero__search {
     align-items: stretch;
   }
 
-  .filter-group select {
+  .hero__search .btn {
     width: 100%;
   }
 }

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -1,26 +1,79 @@
-<%- include('partials/head', { title: 'Gangnam King - 프리미엄 유흥 업소 가이드' }) %>
+<%- include('partials/head', { title: 'Room Guide - 프리미엄 유흥 업소 가이드' }) %>
   <section class="hero">
-    <div class="container hero__content">
-      <h1>강남 최고의 프리미엄 라운지 & 클럽 가이드</h1>
-      <p>지역과 업종을 선택해 원하는 스타일의 업소를 한 번에 찾아보세요.</p>
-      <div class="hero__filters">
-        <div class="filter-group">
-          <label for="area-filter">지역</label>
-          <select id="area-filter">
-            <option value="all">전체</option>
-            <% areas.forEach(function(area) { %>
-              <option value="<%= area %>"><%= area %></option>
-            <% }) %>
-          </select>
+    <div class="hero__overlay"></div>
+    <div class="container hero__container">
+      <div class="hero__text">
+        <span class="badge">서울 · 경기 프리미엄 라운지 큐레이션</span>
+        <h1>검증된 룸과 클럽을 한곳에서, Room Guide</h1>
+        <p>
+          지역과 업종을 선택하면 맞춤형 제휴업체를 바로 확인할 수 있습니다. 모든 파트너는 직접 검수한 신뢰도 높은 공간입니다.
+        </p>
+        <div class="hero__search">
+          <div class="hero__filters">
+            <label class="input-group">
+              <span>지역</span>
+              <select id="area-filter">
+                <option value="all">전체</option>
+                <% areas.forEach(function(area) { %>
+                  <option value="<%= area %>"><%= area %></option>
+                <% }) %>
+              </select>
+            </label>
+            <label class="input-group">
+              <span>업종</span>
+              <select id="category-filter">
+                <option value="all">전체</option>
+                <% categories.forEach(function(category) { %>
+                  <option value="<%= category %>"><%= category %></option>
+                <% }) %>
+              </select>
+            </label>
+          </div>
+          <button class="btn btn--primary btn--large" id="search-button" type="button">검색하기</button>
         </div>
-        <div class="filter-group">
-          <label for="category-filter">업종</label>
-          <select id="category-filter">
-            <option value="all">전체</option>
-            <% categories.forEach(function(category) { %>
-              <option value="<%= category %>"><%= category %></option>
-            <% }) %>
-          </select>
+        <ul class="hero__highlights">
+          <li>실시간 예약 문의 연계</li>
+          <li>전담 매니저 배정</li>
+          <li>VIP 맞춤 코스 추천</li>
+        </ul>
+      </div>
+      <div class="hero__stats">
+        <div class="stat-card">
+          <span class="stat-card__number"><%= shops.length %>+</span>
+          <span class="stat-card__label">제휴된 프리미엄 매장</span>
+        </div>
+        <div class="stat-card">
+          <span class="stat-card__number">24h</span>
+          <span class="stat-card__label">365일 빠른 응대</span>
+        </div>
+        <div class="stat-card">
+          <span class="stat-card__number">1:1</span>
+          <span class="stat-card__label">맞춤형 예약 컨시어지</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="section section--intro">
+    <div class="container section__container">
+      <div>
+        <h2 class="section__title">Room Guide와 함께하는 프리미엄 나이트 라이프</h2>
+        <p class="section__subtitle">
+          트렌디한 라운지부터 하이엔드 클럽까지, 취향에 맞춘 업소를 전문가가 직접 추천해드립니다.
+        </p>
+      </div>
+      <div class="feature-grid">
+        <div class="feature-card">
+          <h3>믿을 수 있는 검수</h3>
+          <p>모든 제휴처는 2단계 검증을 거쳐 등록되며, 예약 품질을 지속적으로 모니터링합니다.</p>
+        </div>
+        <div class="feature-card">
+          <h3>실시간 상담</h3>
+          <p>카카오톡 · 전화 상담을 통해 원하는 시간과 인원에 맞춘 맞춤 코스를 제안합니다.</p>
+        </div>
+        <div class="feature-card">
+          <h3>다양한 혜택</h3>
+          <p>Room Guide 회원만을 위한 특별 할인, 전용 룸 업그레이드 혜택을 제공해드립니다.</p>
         </div>
       </div>
     </div>
@@ -28,7 +81,13 @@
 
   <section class="section" id="areas">
     <div class="container">
-      <h2>지역별 추천</h2>
+      <div class="section__header">
+        <div>
+          <h2 class="section__title">추천 지역별 라운지 &amp; 클럽</h2>
+          <p class="section__subtitle">지역과 업종 필터를 조합해 원하는 매장을 빠르게 찾아보세요.</p>
+        </div>
+        <a class="btn btn--ghost" href="#consult">제휴 문의하기</a>
+      </div>
       <div class="shop-grid" data-grid>
         <% shops.forEach(function(shop) { %>
           <article class="shop-card" data-area="<%= shop.area %>" data-category="<%= shop.category %>">
@@ -36,9 +95,9 @@
               <img src="<%= shop.image %>" alt="<%= shop.name %>" />
             </div>
             <div class="shop-card__body">
-              <p class="shop-card__area"><%= shop.area %> · <%= shop.category %></p>
-              <h3 class="shop-card__title"><%= shop.name %></h3>
-              <p class="shop-card__desc"><%= shop.description %></p>
+              <span class="shop-card__meta"><%= shop.area %> · <%= shop.category %></span>
+              <h3><%= shop.name %></h3>
+              <p><%= shop.description %></p>
               <a class="shop-card__link" href="/shops/<%= shop.id %>">자세히 보기</a>
             </div>
           </article>
@@ -47,15 +106,48 @@
     </div>
   </section>
 
-  <section class="section" id="categories">
+  <section class="section section--muted" id="categories">
     <div class="container">
-      <h2>업종별 큐레이션</h2>
-      <div class="category-list">
+      <h2 class="section__title">업종별 빠른 찾기</h2>
+      <p class="section__subtitle">필터에서 원하는 업종을 선택하면 해당 업소만 모아볼 수 있습니다.</p>
+      <div class="category-chips">
         <% categories.forEach(function(category) { %>
-          <span class="category-pill"><%= category %></span>
+          <span class="category-chip"><%= category %></span>
         <% }) %>
       </div>
-      <p class="section__hint">새로운 업소를 <code>data/shops.json</code>에 추가하면 메인 페이지와 상세 페이지가 자동으로 생성됩니다.</p>
+    </div>
+  </section>
+
+  <section class="section" id="process">
+    <div class="container">
+      <h2 class="section__title">이용 방법</h2>
+      <div class="step-grid">
+        <div class="step-card">
+          <span class="step-card__number">01</span>
+          <h3>필터로 원하는 조건 선택</h3>
+          <p>지역과 업종을 지정하면 가장 잘 맞는 파트너 업소를 추천합니다.</p>
+        </div>
+        <div class="step-card">
+          <span class="step-card__number">02</span>
+          <h3>상담 매니저 연결</h3>
+          <p>상담 버튼을 통해 전담 매니저와 바로 연결되어 일정과 혜택을 확인합니다.</p>
+        </div>
+        <div class="step-card">
+          <span class="step-card__number">03</span>
+          <h3>예약 및 방문</h3>
+          <p>예약이 확정되면 전용 혜택과 함께 즐거운 시간을 보낼 수 있도록 안내합니다.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="section section--cta">
+    <div class="container section--cta__content">
+      <div>
+        <h2 class="section__title">제휴 파트너가 되어보세요</h2>
+        <p class="section__subtitle">Room Guide 네트워크에 합류하여 더 많은 프리미엄 고객을 만나보세요.</p>
+      </div>
+      <a class="btn btn--primary btn--large" href="tel:01000000000">제휴 상담 바로 연결</a>
     </div>
   </section>
 <%- include('partials/footer', { scripts: ['/scripts/filters.js'] }) %>

--- a/views/partials/footer.ejs
+++ b/views/partials/footer.ejs
@@ -1,7 +1,29 @@
     </main>
-    <footer class="site-footer">
-      <div class="container">
-        <p>© <%= new Date().getFullYear() %> Gangnam King. 모든 권리 보유.</p>
+    <footer class="site-footer" id="consult">
+      <div class="container site-footer__content">
+        <div>
+          <h3>Room Guide</h3>
+          <p>강남 · 경기권 프리미엄 라운지와 클럽을 검증된 파트너 네트워크로 연결해드립니다.</p>
+        </div>
+        <div>
+          <h4>상담 안내</h4>
+          <ul>
+            <li>제휴 문의: <a href="tel:01000000000">010-0000-0000</a></li>
+            <li>운영 시간: 12:00 ~ 03:00</li>
+            <li>카카오톡: @roomguide</li>
+          </ul>
+        </div>
+        <div>
+          <h4>바로가기</h4>
+          <ul>
+            <li><a href="#areas">추천 지역</a></li>
+            <li><a href="#categories">업종별 찾기</a></li>
+            <li><a href="#process">이용 방법</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="site-footer__bottom">
+        <p>© <%= new Date().getFullYear() %> Room Guide. All rights reserved.</p>
       </div>
     </footer>
     <% if (scripts) { %>

--- a/views/partials/head.ejs
+++ b/views/partials/head.ejs
@@ -14,12 +14,27 @@
   </head>
   <body>
     <header class="site-header">
-      <div class="container">
-        <a class="branding" href="/">Gangnam King</a>
+      <div class="site-header__topbar">
+        <div class="container">
+          <span>서울 · 경기 프리미엄 룸 네트워크</span>
+          <div class="topbar__links">
+            <a href="#consult">제휴 문의</a>
+            <a href="tel:01000000000">고객센터 010-0000-0000</a>
+          </div>
+        </div>
+      </div>
+      <div class="container site-header__main">
+        <a class="branding" href="/">Room Guide</a>
         <nav class="nav">
-          <a href="#areas">지역별 보기</a>
-          <a href="#categories">업종별 보기</a>
+          <a href="#areas">추천 지역</a>
+          <a href="#categories">업종별 찾기</a>
+          <a href="#process">이용 방법</a>
+          <a href="#consult">제휴 안내</a>
         </nav>
+        <div class="header-actions">
+          <a class="btn btn--ghost" href="#areas">바로 둘러보기</a>
+          <a class="btn btn--primary" href="#consult">빠른 상담</a>
+        </div>
       </div>
     </header>
     <main class="site-main">


### PR DESCRIPTION
## Summary
- Rebuild the landing page hero, feature highlights, listings, and CTA sections to follow the Room Guide structure
- Refresh the shared header and footer partials with top bar info, action buttons, and quick links consistent with the new layout
- Update global styles and filter scripting to match the new aesthetic and support the search trigger button

## Testing
- npm install *(fails: 403 Forbidden - GET https://registry.npmjs.org/ejs)*

------
https://chatgpt.com/codex/tasks/task_e_68e419214b388325b9e13abe4831f999