### PR TITLE
Add regional filtering and enhance shop detail presentation

### DIFF
--- a/app.js
+++ b/app.js
@@ -32,13 +32,27 @@ app.set('views', path.join(__dirname, 'views'));
 app.use(express.static(path.join(__dirname, 'public')));
 
 app.get('/', (req, res) => {
-  const areas = [...new Set(shops.map((shop) => shop.area))];
+  const regions = [...new Set(shops.map((shop) => shop.region))];
   const categories = [...new Set(shops.map((shop) => shop.category))];
+  const districtMap = regions.reduce((acc, region) => {
+    const districts = shops
+      .filter((shop) => shop.region === region)
+      .map((shop) => shop.district);
+    acc[region] = [...new Set(districts)];
+    return acc;
+  }, {});
+  const seoKeywords = [
+    ...new Set(
+      shops.flatMap((shop) => Array.isArray(shop.seoKeywords) ? shop.seoKeywords : [])
+    )
+  ];
 
   res.render('index', {
     shops,
-    areas,
-    categories
+    regions,
+    categories,
+    districtMap,
+    seoKeywords
   });
 });
 
@@ -50,7 +64,8 @@ app.get('/shops/:id', (req, res, next) => {
   }
 
   res.render('shop', {
-    shop
+    shop,
+    seoKeywords: Array.isArray(shop.seoKeywords) ? shop.seoKeywords : []
   });
 });
 

--- a/data/shops.json
+++ b/data/shops.json
@@ -1,50 +1,167 @@
 [
   {
-    "id": "gangnam-lounge-101",
+    "id": "seoul-gangnam-lounge-101",
     "name": "강남 라운지 101",
-    "area": "강남",
+    "region": "서울",
+    "district": "강남구",
     "category": "라운지바",
-    "address": "서울 강남구 테헤란로 101",
+    "address": "서울특별시 강남구 테헤란로 101",
     "phone": "02-000-0101",
     "hours": "매일 18:00 - 04:00",
-    "description": "감각적인 인테리어와 전문 바텐더가 있는 프리미엄 라운지입니다.",
+    "description": "감각적인 무드와 전문 바텐더가 선사하는 시그니처 칵테일이 돋보이는 프리미엄 라운지입니다.",
     "highlights": [
-      "수제 칵테일",
-      "DJ 라운지",
-      "프라이빗 룸"
+      "수제 시그니처 칵테일",
+      "DJ 라운지 퍼포먼스",
+      "프라이빗 VIP 룸"
+    ],
+    "pricing": {
+      "base": "주중 50만 원대~, 주말 60만 원대~",
+      "tc": "TC 12만 원부터",
+      "rt": "RT 40만 원부터"
+    },
+    "manager": {
+      "name": "김매니저",
+      "phone": "010-1234-5678",
+      "kakao": "@gangnam101"
+    },
+    "seoKeywords": [
+      "강남 라운지",
+      "강남 프리미엄 바",
+      "강남 VIP 룸",
+      "서울 라운지 추천"
     ],
     "image": "/images/gangnam-lounge-101.svg"
   },
   {
-    "id": "cheongdam-vip",
-    "name": "청담 VIP 클럽",
-    "area": "강남",
-    "category": "클럽",
-    "address": "서울 강남구 청담동 12-3",
-    "phone": "02-000-0202",
-    "hours": "목-토 21:00 - 06:00",
-    "description": "최신 사운드 시스템과 화려한 라이브 퍼포먼스가 있는 하이엔드 클럽.",
+    "id": "seoul-gwanak-premium-room",
+    "name": "관악 프리미엄 룸",
+    "region": "서울",
+    "district": "관악구",
+    "category": "룸살롱",
+    "address": "서울특별시 관악구 봉천로 325",
+    "phone": "02-000-0404",
+    "hours": "월-토 18:00 - 03:00",
+    "description": "단골 비즈니스 고객에게 최적화된 프라이빗 룸과 맞춤 테이블 세팅을 제공하는 하이엔드 룸살롱입니다.",
     "highlights": [
-      "주말 라이브 공연",
-      "VIP 전용 라운지",
-      "발렛 파킹"
+      "전담 매니저 상주",
+      "비즈니스 맞춤 코스",
+      "주차 대행 서비스"
     ],
-    "image": "/images/cheongdam-vip.svg"
+    "pricing": {
+      "base": "주중 45만 원대~, 주말 55만 원대~",
+      "tc": "TC 10만 원부터",
+      "rt": "RT 35만 원부터"
+    },
+    "manager": {
+      "name": "이매니저",
+      "phone": "010-9876-5432",
+      "kakao": "@gwanakroom"
+    },
+    "seoKeywords": [
+      "관악 룸살롱",
+      "서울 관악 유흥",
+      "관악 주대 정보",
+      "비즈니스 접대 장소"
+    ],
+    "image": "/images/gwanak-premium-room.svg"
   },
   {
-    "id": "sinsa-whisky-house",
-    "name": "신사 위스키 하우스",
-    "area": "강남",
-    "category": "위스키바",
-    "address": "서울 강남구 신사동 45-7",
-    "phone": "02-000-0303",
-    "hours": "월-토 17:00 - 02:00",
-    "description": "세계 각국의 위스키 컬렉션과 시그니처 안주를 즐길 수 있는 바.",
+    "id": "seoul-gangseo-night-suite",
+    "name": "강서 나이트 스위트",
+    "region": "서울",
+    "district": "강서구",
+    "category": "하이엔드바",
+    "address": "서울특별시 강서구 마곡동 512",
+    "phone": "02-000-0505",
+    "hours": "매일 19:00 - 05:00",
+    "description": "루프탑과 연계된 이중 공간으로 사계절 내내 색다른 무드를 즐길 수 있는 하이엔드 바입니다.",
     "highlights": [
-      "위스키 시음 프로그램",
-      "예약제 프라이빗 테이블",
-      "소믈리에 추천 페어링"
+      "사계절 루프탑",
+      "프리미엄 위스키 셀렉션",
+      "아티스트 라이브 세션"
     ],
-    "image": "/images/sinsa-whisky-house.svg"
+    "pricing": {
+      "base": "주중 40만 원대~, 주말 50만 원대~",
+      "tc": "TC 9만 원부터",
+      "rt": "RT 32만 원부터"
+    },
+    "manager": {
+      "name": "박매니저",
+      "phone": "010-3333-2222",
+      "kakao": "@gangseoelite"
+    },
+    "seoKeywords": [
+      "강서 하이엔드바",
+      "마곡 루프탑 바",
+      "서울 강서 유흥",
+      "강서 나이트 예약"
+    ],
+    "image": "/images/gangseo-night-suite.svg"
+  },
+  {
+    "id": "busan-haeundae-ocean-lounge",
+    "name": "해운대 오션 라운지",
+    "region": "부산",
+    "district": "해운대구",
+    "category": "오션뷰 라운지",
+    "address": "부산광역시 해운대구 달맞이길 72",
+    "phone": "051-000-0707",
+    "hours": "매일 17:00 - 03:00",
+    "description": "부산 바다 전망과 함께 와인과 위스키 페어링을 즐길 수 있는 오션뷰 라운지입니다.",
+    "highlights": [
+      "전 객실 오션뷰",
+      "소믈리에 페어링",
+      "실시간 요트 연계"
+    ],
+    "pricing": {
+      "base": "주중 35만 원대~, 주말 45만 원대~",
+      "tc": "TC 8만 원부터",
+      "rt": "RT 28만 원부터"
+    },
+    "manager": {
+      "name": "최매니저",
+      "phone": "010-5555-4444",
+      "kakao": "@oceanlounge"
+    },
+    "seoKeywords": [
+      "해운대 라운지",
+      "부산 오션뷰 바",
+      "해운대 주대",
+      "부산 프리미엄 라운지"
+    ],
+    "image": "/images/haeundae-ocean-lounge.svg"
+  },
+  {
+    "id": "busan-seomyeon-velvet-club",
+    "name": "서면 벨벳 클럽",
+    "region": "부산",
+    "district": "부산진구",
+    "category": "클럽",
+    "address": "부산광역시 부산진구 중앙대로 686",
+    "phone": "051-000-0909",
+    "hours": "금-일 20:00 - 06:00",
+    "description": "최신 EDM 사운드와 고급 조명 연출로 유명한 부산 대표 프리미엄 클럽입니다.",
+    "highlights": [
+      "유명 DJ 레지던트",
+      "VIP 전용 부스",
+      "생일 파티 패키지"
+    ],
+    "pricing": {
+      "base": "주말 55만 원대~",
+      "tc": "TC 11만 원부터",
+      "rt": "RT 36만 원부터"
+    },
+    "manager": {
+      "name": "정매니저",
+      "phone": "010-7777-6666",
+      "kakao": "@velvetclub"
+    },
+    "seoKeywords": [
+      "부산 서면 클럽",
+      "서면 프리미엄 클럽",
+      "부산 클럽 주대",
+      "부산 EDM 클럽"
+    ],
+    "image": "/images/seomyeon-velvet-club.svg"
   }
 ]

--- a/public/images/gangseo-night-suite.svg
+++ b/public/images/gangseo-night-suite.svg
@@ -1,0 +1,8 @@
+<svg width="320" height="180" viewBox="0 0 320 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="320" height="180" rx="24" fill="#0f1119"/>
+  <circle cx="80" cy="90" r="48" fill="#1d2236" stroke="#4f8cff" stroke-width="4"/>
+  <circle cx="160" cy="90" r="60" fill="#141724" stroke="#ff7c4d" stroke-width="4"/>
+  <circle cx="240" cy="90" r="40" fill="#1d2236" stroke="#8f6bff" stroke-width="4"/>
+  <path d="M40 130H280" stroke="#2a2f45" stroke-width="6" stroke-linecap="round"/>
+  <text x="160" y="160" text-anchor="middle" fill="#a3a9c2" font-family="'Pretendard', sans-serif" font-size="18">Gangseo Night</text>
+</svg>

--- a/public/images/gwanak-premium-room.svg
+++ b/public/images/gwanak-premium-room.svg
@@ -1,0 +1,8 @@
+<svg width="320" height="180" viewBox="0 0 320 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="320" height="180" rx="24" fill="#141724"/>
+  <rect x="20" y="20" width="280" height="140" rx="18" fill="#1f2233" stroke="#3a3f5c" stroke-width="2" stroke-dasharray="8 8"/>
+  <path d="M60 130L90 70L120 130" stroke="#ff496a" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M140 130V70H200V130" stroke="#4f8cff" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M220 130L250 90L280 130" stroke="#8f6bff" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="160" y="160" text-anchor="middle" fill="#a3a9c2" font-family="'Pretendard', sans-serif" font-size="18">Gwanak Premium</text>
+</svg>

--- a/public/images/haeundae-ocean-lounge.svg
+++ b/public/images/haeundae-ocean-lounge.svg
@@ -1,0 +1,7 @@
+<svg width="320" height="180" viewBox="0 0 320 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="320" height="180" rx="24" fill="#10202e"/>
+  <path d="M0 120C40 110 80 140 120 132C160 124 200 96 240 100C280 104 300 120 320 128V180H0V120Z" fill="#1d3952"/>
+  <path d="M0 130C40 118 80 146 120 138C160 130 200 104 240 108C280 112 300 128 320 136V180H0V130Z" fill="#3a6fa3" opacity="0.6"/>
+  <circle cx="250" cy="50" r="26" fill="#ffdd80"/>
+  <text x="160" y="160" text-anchor="middle" fill="#cde7ff" font-family="'Pretendard', sans-serif" font-size="18">Haeundae Ocean</text>
+</svg>

--- a/public/images/seomyeon-velvet-club.svg
+++ b/public/images/seomyeon-velvet-club.svg
@@ -1,0 +1,14 @@
+<svg width="320" height="180" viewBox="0 0 320 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="320" height="180" rx="24" fill="#1a0f24"/>
+  <g filter="url(#glow)">
+    <ellipse cx="110" cy="100" rx="48" ry="36" fill="#ff496a" opacity="0.7"/>
+    <ellipse cx="210" cy="90" rx="54" ry="40" fill="#8f6bff" opacity="0.7"/>
+  </g>
+  <path d="M60 140H260" stroke="#2d1438" stroke-width="8" stroke-linecap="round"/>
+  <text x="160" y="160" text-anchor="middle" fill="#f1d9ff" font-family="'Pretendard', sans-serif" font-size="18">Velvet Club</text>
+  <defs>
+    <filter id="glow" x="30" y="30" width="260" height="140" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="20" result="blur"/>
+    </filter>
+  </defs>
+</svg>

--- a/public/scripts/filters.js
+++ b/public/scripts/filters.js
@@ -1,23 +1,56 @@
 (function () {
-  const areaFilter = document.getElementById('area-filter');
+  const regionFilter = document.getElementById('region-filter');
+  const districtFilter = document.getElementById('district-filter');
   const categoryFilter = document.getElementById('category-filter');
   const cards = document.querySelectorAll('[data-grid] .shop-card');
   const searchButton = document.getElementById('search-button');
+  const mappingElement = document.getElementById('region-district-data');
+  const districtMap = mappingElement ? JSON.parse(mappingElement.textContent || '{}') : {};
+
+  function populateDistricts(region) {
+    if (!districtFilter) {
+      return;
+    }
+
+    const options = ['<option value="all">전체</option>'];
+
+    if (region !== 'all' && districtMap[region]) {
+      districtMap[region].forEach((district) => {
+        options.push(`<option value="${district}">${district}</option>`);
+      });
+      districtFilter.innerHTML = options.join('');
+      districtFilter.disabled = false;
+    } else {
+      districtFilter.innerHTML = options.join('');
+      districtFilter.disabled = true;
+    }
+
+    districtFilter.value = 'all';
+  }
 
   function applyFilters() {
-    const areaValue = areaFilter ? areaFilter.value : 'all';
+    const regionValue = regionFilter ? regionFilter.value : 'all';
+    const districtValue = districtFilter && !districtFilter.disabled ? districtFilter.value : 'all';
     const categoryValue = categoryFilter ? categoryFilter.value : 'all';
 
     cards.forEach((card) => {
-      const isAreaMatch = areaValue === 'all' || card.dataset.area === areaValue;
-      const isCategoryMatch =
-        categoryValue === 'all' || card.dataset.category === categoryValue;
-      card.style.display = isAreaMatch && isCategoryMatch ? 'flex' : 'none';
+      const matchesRegion = regionValue === 'all' || card.dataset.region === regionValue;
+      const matchesDistrict = districtValue === 'all' || card.dataset.district === districtValue;
+      const matchesCategory = categoryValue === 'all' || card.dataset.category === categoryValue;
+
+      card.style.display = matchesRegion && matchesDistrict && matchesCategory ? 'flex' : 'none';
     });
   }
 
-  if (areaFilter) {
-    areaFilter.addEventListener('change', applyFilters);
+  if (regionFilter) {
+    regionFilter.addEventListener('change', (event) => {
+      populateDistricts(event.target.value);
+      applyFilters();
+    });
+  }
+
+  if (districtFilter) {
+    districtFilter.addEventListener('change', applyFilters);
   }
 
   if (categoryFilter) {
@@ -33,4 +66,6 @@
       }
     });
   }
+
+  populateDistricts(regionFilter ? regionFilter.value : 'all');
 })();

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -349,6 +349,17 @@ img {
   margin: 0;
   color: var(--color-muted);
 }
+.shop-card__contact {
+  font-size: 0.9rem;
+  color: var(--color-muted);
+}
+.shop-card__contact strong {
+  color: var(--color-text);
+}
+.shop-card__contact a {
+  color: inherit;
+  font-weight: 600;
+}
 
 .shop-card__link {
   margin-top: auto;
@@ -398,6 +409,15 @@ img {
 .detail-hero__list dd {
   margin: 0;
 }
+.detail-hero__manager-contact {
+  display: block;
+  margin-top: 0.25rem;
+  color: var(--color-muted);
+}
+.detail-hero__manager-contact a {
+  color: inherit;
+  font-weight: 600;
+}
 
 .highlight-list {
   list-style: none;
@@ -412,6 +432,50 @@ img {
   background: rgba(15, 17, 25, 0.75);
   border-radius: 14px;
   border: 1px solid var(--color-border);
+}
+.pricing-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.5rem;
+}
+.pricing-card {
+  background: rgba(15, 17, 25, 0.8);
+  border-radius: 18px;
+  border: 1px solid var(--color-border);
+  padding: 1.75rem;
+  text-align: center;
+}
+.pricing-card h3 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+}
+.pricing-card p {
+  margin: 0;
+  color: var(--color-muted);
+  font-weight: 500;
+}
+.contact-card {
+  background: rgba(7, 9, 15, 0.7);
+  border-radius: 20px;
+  border: 1px solid var(--color-border);
+  padding: 2rem;
+}
+.contact-card ul {
+  list-style: none;
+  padding: 0;
+  margin: 1.25rem 0 0;
+  display: grid;
+  gap: 0.75rem;
+}
+.contact-card li {
+  color: var(--color-muted);
+}
+.contact-card a {
+  color: inherit;
+  font-weight: 600;
+}
+.seo-keywords {
+  display: none;
 }
 
 .back-link {

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -1,22 +1,29 @@
-<%- include('partials/head', { title: 'Room Guide - 프리미엄 유흥 업소 가이드' }) %>
+<%- include('partials/head', { title: 'Room Guide - 프리미엄 유흥 업소 가이드', seoKeywords }) %>
   <section class="hero">
     <div class="hero__overlay"></div>
     <div class="container hero__container">
       <div class="hero__text">
-        <span class="badge">서울 · 경기 프리미엄 라운지 큐레이션</span>
+        <span class="badge">서울 · 부산 프리미엄 라운지 큐레이션</span>
         <h1>검증된 룸과 클럽을 한곳에서, Room Guide</h1>
         <p>
-          지역과 업종을 선택하면 맞춤형 제휴업체를 바로 확인할 수 있습니다. 모든 파트너는 직접 검수한 신뢰도 높은 공간입니다.
+          지역 → 구 → 업종 순으로 정교하게 나뉜 필터를 활용하면 맞춤형 제휴업체를 바로 확인할 수 있습니다.
+          모든 파트너는 직접 검수한 신뢰도 높은 공간입니다.
         </p>
         <div class="hero__search">
           <div class="hero__filters">
             <label class="input-group">
               <span>지역</span>
-              <select id="area-filter">
+              <select id="region-filter">
                 <option value="all">전체</option>
-                <% areas.forEach(function(area) { %>
-                  <option value="<%= area %>"><%= area %></option>
+                <% regions.forEach(function(region) { %>
+                  <option value="<%= region %>"><%= region %></option>
                 <% }) %>
+              </select>
+            </label>
+            <label class="input-group">
+              <span>구 / 군</span>
+              <select id="district-filter" disabled>
+                <option value="all">전체</option>
               </select>
             </label>
             <label class="input-group">
@@ -84,20 +91,26 @@
       <div class="section__header">
         <div>
           <h2 class="section__title">추천 지역별 라운지 &amp; 클럽</h2>
-          <p class="section__subtitle">지역과 업종 필터를 조합해 원하는 매장을 빠르게 찾아보세요.</p>
+          <p class="section__subtitle">지역 → 구 → 업종 필터를 조합해 원하는 매장을 빠르게 찾아보세요.</p>
         </div>
         <a class="btn btn--ghost" href="#consult">제휴 문의하기</a>
       </div>
       <div class="shop-grid" data-grid>
         <% shops.forEach(function(shop) { %>
-          <article class="shop-card" data-area="<%= shop.area %>" data-category="<%= shop.category %>">
+          <article
+            class="shop-card"
+            data-region="<%= shop.region %>"
+            data-district="<%= shop.district %>"
+            data-category="<%= shop.category %>"
+          >
             <div class="shop-card__image">
               <img src="<%= shop.image %>" alt="<%= shop.name %>" />
             </div>
             <div class="shop-card__body">
-              <span class="shop-card__meta"><%= shop.area %> · <%= shop.category %></span>
+              <span class="shop-card__meta"><%= shop.region %> · <%= shop.district %> · <%= shop.category %></span>
               <h3><%= shop.name %></h3>
               <p><%= shop.description %></p>
+              <p class="shop-card__contact">담당 <strong><%= shop.manager.name %></strong> · <a href="tel:<%= shop.manager.phone %>"><%= shop.manager.phone %></a></p>
               <a class="shop-card__link" href="/shops/<%= shop.id %>">자세히 보기</a>
             </div>
           </article>
@@ -150,4 +163,11 @@
       <a class="btn btn--primary btn--large" href="tel:01000000000">제휴 상담 바로 연결</a>
     </div>
   </section>
+
+  <script id="region-district-data" type="application/json">
+    <%- JSON.stringify(districtMap) %>
+  </script>
+  <div class="seo-keywords" aria-hidden="true">
+    <%- seoKeywords.join(', ') %>
+  </div>
 <%- include('partials/footer', { scripts: ['/scripts/filters.js'] }) %>

--- a/views/partials/head.ejs
+++ b/views/partials/head.ejs
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title><%= title %></title>
+    <% if (seoKeywords && seoKeywords.length) { %>
+      <meta name="keywords" content="<%= seoKeywords.join(', ') %>" />
+    <% } %>
     <link rel="stylesheet" href="/styles/main.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/views/shop.ejs
+++ b/views/shop.ejs
@@ -1,11 +1,11 @@
-<%- include('partials/head', { title: shop.name + ' - Gangnam King' }) %>
+<%- include('partials/head', { title: shop.name + ' - Room Guide', seoKeywords }) %>
   <section class="detail-hero">
     <div class="container detail-hero__content">
       <div class="detail-hero__image">
         <img src="<%= shop.image %>" alt="<%= shop.name %>" />
       </div>
       <div class="detail-hero__info">
-        <p class="detail-hero__meta"><%= shop.area %> · <%= shop.category %></p>
+        <p class="detail-hero__meta"><%= shop.region %> · <%= shop.district %> · <%= shop.category %></p>
         <h1><%= shop.name %></h1>
         <p class="detail-hero__description"><%= shop.description %></p>
         <dl class="detail-hero__list">
@@ -14,8 +14,20 @@
             <dd><%= shop.address %></dd>
           </div>
           <div>
-            <dt>전화번호</dt>
+            <dt>대표 전화</dt>
             <dd><a href="tel:<%= shop.phone %>"><%= shop.phone %></a></dd>
+          </div>
+          <div>
+            <dt>담당 매니저</dt>
+            <dd>
+              <strong><%= shop.manager.name %></strong>
+              <span class="detail-hero__manager-contact">
+                <a href="tel:<%= shop.manager.phone %>"><%= shop.manager.phone %></a>
+                <% if (shop.manager.kakao) { %>
+                  · 카카오톡 <%= shop.manager.kakao %>
+                <% } %>
+              </span>
+            </dd>
           </div>
           <div>
             <dt>영업시간</dt>
@@ -23,6 +35,42 @@
           </div>
         </dl>
         <a class="back-link" href="/">← 메인으로 돌아가기</a>
+      </div>
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="container">
+      <h2>요금 안내</h2>
+      <div class="pricing-grid">
+        <div class="pricing-card">
+          <h3>주대</h3>
+          <p><%= shop.pricing.base %></p>
+        </div>
+        <div class="pricing-card">
+          <h3>TC</h3>
+          <p><%= shop.pricing.tc %></p>
+        </div>
+        <div class="pricing-card">
+          <h3>RT</h3>
+          <p><%= shop.pricing.rt %></p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="section section--muted">
+    <div class="container">
+      <h2>담당자 상담 채널</h2>
+      <div class="contact-card">
+        <p>전담 매니저가 예약, 혜택, 행사 문의를 실시간으로 응대해드립니다.</p>
+        <ul>
+          <li><strong>담당자</strong> <%= shop.manager.name %></li>
+          <li><strong>연락처</strong> <a href="tel:<%= shop.manager.phone %>"><%= shop.manager.phone %></a></li>
+          <% if (shop.manager.kakao) { %>
+            <li><strong>카카오톡</strong> <%= shop.manager.kakao %></li>
+          <% } %>
+        </ul>
       </div>
     </div>
   </section>
@@ -37,4 +85,8 @@
       </ul>
     </div>
   </section>
+
+  <div class="seo-keywords" aria-hidden="true">
+    <%- (seoKeywords || []).join(', ') %>
+  </div>
 <%- include('partials/footer') %>


### PR DESCRIPTION
## Summary
- restructure shop data to include region, district, pricing, manager contacts, and SEO keywords
- update the home page to filter by region→district→category and surface manager contact info with hidden SEO terms
- expand shop detail pages with pricing breakdown, manager contact section, and supporting artwork assets

## Testing
- node app.js *(fails: missing express dependency in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e41d8d4d2c83259eb49b56be9b7fc1