### PR TITLE
Redesign 룸빵일번지 pages with immersive detail view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.DS_Store
+npm-debug.log*

--- a/data/shops.json
+++ b/data/shops.json
@@ -24,6 +24,20 @@
       "phone": "010-1234-5678",
       "kakao": "@gangnam101"
     },
+    "gallery": [
+      {
+        "src": "/images/gangnam-lounge-101.svg",
+        "alt": "강남 라운지 101 메인 홀"
+      },
+      {
+        "src": "/images/gallery-neon-1.svg",
+        "alt": "강남 라운지 101 네온 바 카운터"
+      },
+      {
+        "src": "/images/gallery-neon-3.svg",
+        "alt": "강남 라운지 101 프라이빗 룸"
+      }
+    ],
     "seoKeywords": [
       "강남 라운지",
       "강남 프리미엄 바",
@@ -57,6 +71,20 @@
       "phone": "010-9876-5432",
       "kakao": "@gwanakroom"
     },
+    "gallery": [
+      {
+        "src": "/images/gwanak-premium-room.svg",
+        "alt": "관악 프리미엄 룸 리셉션"
+      },
+      {
+        "src": "/images/gallery-neon-2.svg",
+        "alt": "관악 프리미엄 룸 라운지 존"
+      },
+      {
+        "src": "/images/gallery-neon-4.svg",
+        "alt": "관악 프리미엄 룸 프라이빗 테이블"
+      }
+    ],
     "seoKeywords": [
       "관악 룸살롱",
       "서울 관악 유흥",
@@ -90,6 +118,20 @@
       "phone": "010-3333-2222",
       "kakao": "@gangseoelite"
     },
+    "gallery": [
+      {
+        "src": "/images/gangseo-night-suite.svg",
+        "alt": "강서 나이트 스위트 라운지"
+      },
+      {
+        "src": "/images/gallery-neon-5.svg",
+        "alt": "강서 나이트 스위트 루프탑 바"
+      },
+      {
+        "src": "/images/gallery-neon-2.svg",
+        "alt": "강서 나이트 스위트 시그니처 좌석"
+      }
+    ],
     "seoKeywords": [
       "강서 하이엔드바",
       "마곡 루프탑 바",
@@ -123,6 +165,20 @@
       "phone": "010-5555-4444",
       "kakao": "@oceanlounge"
     },
+    "gallery": [
+      {
+        "src": "/images/haeundae-ocean-lounge.svg",
+        "alt": "해운대 오션 라운지 전경"
+      },
+      {
+        "src": "/images/gallery-neon-3.svg",
+        "alt": "해운대 오션 라운지 오션뷰 좌석"
+      },
+      {
+        "src": "/images/gallery-neon-1.svg",
+        "alt": "해운대 오션 라운지 바 존"
+      }
+    ],
     "seoKeywords": [
       "해운대 라운지",
       "부산 오션뷰 바",
@@ -156,6 +212,20 @@
       "phone": "010-7777-6666",
       "kakao": "@velvetclub"
     },
+    "gallery": [
+      {
+        "src": "/images/seomyeon-velvet-club.svg",
+        "alt": "서면 벨벳 클럽 메인 스테이지"
+      },
+      {
+        "src": "/images/gallery-neon-4.svg",
+        "alt": "서면 벨벳 클럽 DJ 부스"
+      },
+      {
+        "src": "/images/gallery-neon-5.svg",
+        "alt": "서면 벨벳 클럽 VIP 존"
+      }
+    ],
     "seoKeywords": [
       "부산 서면 클럽",
       "서면 프리미엄 클럽",

--- a/public/images/gallery-neon-1.svg
+++ b/public/images/gallery-neon-1.svg
@@ -1,0 +1,33 @@
+<svg width="1200" height="800" viewBox="0 0 1200 800" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="800" fill="#0B0518" />
+  <g filter="url(#glow1)">
+    <circle cx="300" cy="180" r="220" fill="#FF2E8B" fill-opacity="0.45" />
+  </g>
+  <g filter="url(#glow2)">
+    <circle cx="980" cy="220" r="260" fill="#8F5BFF" fill-opacity="0.4" />
+  </g>
+  <rect x="220" y="280" width="760" height="340" rx="48" fill="url(#paint0)" opacity="0.65" />
+  <rect x="260" y="320" width="320" height="260" rx="28" fill="url(#paint1)" opacity="0.85" />
+  <rect x="620" y="320" width="300" height="200" rx="24" fill="url(#paint2)" opacity="0.85" />
+  <rect x="620" y="540" width="300" height="60" rx="24" fill="#150D2B" opacity="0.9" />
+  <defs>
+    <filter id="glow1" x="-120" y="-240" width="840" height="840" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="60" />
+    </filter>
+    <filter id="glow2" x="620" y="-140" width="720" height="720" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="80" />
+    </filter>
+    <linearGradient id="paint0" x1="220" y1="280" x2="980" y2="620" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#251143" />
+      <stop offset="1" stop-color="#100722" />
+    </linearGradient>
+    <linearGradient id="paint1" x1="260" y1="320" x2="580" y2="580" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FF4FA4" stop-opacity="0.9" />
+      <stop offset="1" stop-color="#251040" stop-opacity="0.9" />
+    </linearGradient>
+    <linearGradient id="paint2" x1="620" y1="320" x2="920" y2="520" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#8F5BFF" stop-opacity="0.9" />
+      <stop offset="1" stop-color="#211047" stop-opacity="0.9" />
+    </linearGradient>
+  </defs>
+</svg>

--- a/public/images/gallery-neon-2.svg
+++ b/public/images/gallery-neon-2.svg
@@ -1,0 +1,29 @@
+<svg width="1200" height="800" viewBox="0 0 1200 800" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="800" fill="#09041A" />
+  <g filter="url(#glow1)">
+    <circle cx="220" cy="420" r="260" fill="#8F5BFF" fill-opacity="0.4" />
+  </g>
+  <g filter="url(#glow2)">
+    <circle cx="920" cy="200" r="240" fill="#FF2E8B" fill-opacity="0.42" />
+  </g>
+  <path d="M140 620H1060L1020 760H180L140 620Z" fill="url(#paint0)" opacity="0.8" />
+  <rect x="320" y="220" width="560" height="320" rx="40" fill="url(#paint1)" opacity="0.85" />
+  <rect x="360" y="260" width="220" height="180" rx="26" fill="#1C0F38" />
+  <rect x="620" y="260" width="220" height="180" rx="26" fill="#201046" />
+  <defs>
+    <filter id="glow1" x="-160" y="40" width="760" height="760" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="70" />
+    </filter>
+    <filter id="glow2" x="580" y="-140" width="680" height="680" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="70" />
+    </filter>
+    <linearGradient id="paint0" x1="140" y1="620" x2="1060" y2="760" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#1B0C35" />
+      <stop offset="1" stop-color="#120924" />
+    </linearGradient>
+    <linearGradient id="paint1" x1="320" y1="220" x2="880" y2="540" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#3A145D" />
+      <stop offset="1" stop-color="#120822" />
+    </linearGradient>
+  </defs>
+</svg>

--- a/public/images/gallery-neon-3.svg
+++ b/public/images/gallery-neon-3.svg
@@ -1,0 +1,24 @@
+<svg width="1200" height="800" viewBox="0 0 1200 800" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="800" fill="#0B051C" />
+  <g filter="url(#glow1)">
+    <ellipse cx="960" cy="580" rx="280" ry="220" fill="#FF2E8B" fill-opacity="0.36" />
+  </g>
+  <g filter="url(#glow2)">
+    <ellipse cx="320" cy="240" rx="220" ry="180" fill="#8F5BFF" fill-opacity="0.42" />
+  </g>
+  <rect x="160" y="360" width="880" height="220" rx="36" fill="url(#paint0)" opacity="0.8" />
+  <rect x="220" y="280" width="240" height="200" rx="30" fill="#1F0E3F" opacity="0.9" />
+  <rect x="940" y="240" width="80" height="320" rx="28" fill="#1A0D33" />
+  <defs>
+    <filter id="glow1" x="520" y="220" width="880" height="720" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="80" />
+    </filter>
+    <filter id="glow2" x="0" y="0" width="640" height="480" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="70" />
+    </filter>
+    <linearGradient id="paint0" x1="160" y1="360" x2="1040" y2="580" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#2A1044" />
+      <stop offset="1" stop-color="#11071F" />
+    </linearGradient>
+  </defs>
+</svg>

--- a/public/images/gallery-neon-4.svg
+++ b/public/images/gallery-neon-4.svg
@@ -1,0 +1,26 @@
+<svg width="1200" height="800" viewBox="0 0 1200 800" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="800" fill="#09031A" />
+  <g filter="url(#glow1)">
+    <circle cx="420" cy="200" r="200" fill="#FF2E8B" fill-opacity="0.38" />
+  </g>
+  <g filter="url(#glow2)">
+    <circle cx="820" cy="540" r="260" fill="#8F5BFF" fill-opacity="0.4" />
+  </g>
+  <rect x="220" y="260" width="760" height="280" rx="42" fill="url(#paint0)" opacity="0.9" />
+  <rect x="260" y="300" width="240" height="200" rx="24" fill="#1A0C30" />
+  <rect x="540" y="300" width="400" height="200" rx="24" fill="#1E0E3A" />
+  <circle cx="320" cy="620" r="80" fill="#FF2E8B" fill-opacity="0.35" />
+  <circle cx="480" cy="620" r="60" fill="#8F5BFF" fill-opacity="0.3" />
+  <defs>
+    <filter id="glow1" x="60" y="-160" width="720" height="720" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="70" />
+    </filter>
+    <filter id="glow2" x="460" y="180" width="720" height="720" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="90" />
+    </filter>
+    <linearGradient id="paint0" x1="220" y1="260" x2="980" y2="540" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#2B0F46" />
+      <stop offset="1" stop-color="#110722" />
+    </linearGradient>
+  </defs>
+</svg>

--- a/public/images/gallery-neon-5.svg
+++ b/public/images/gallery-neon-5.svg
@@ -1,0 +1,25 @@
+<svg width="1200" height="800" viewBox="0 0 1200 800" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="800" fill="#08031A" />
+  <g filter="url(#glow1)">
+    <circle cx="1040" cy="260" r="220" fill="#FF2E8B" fill-opacity="0.45" />
+  </g>
+  <g filter="url(#glow2)">
+    <circle cx="200" cy="220" r="200" fill="#8F5BFF" fill-opacity="0.4" />
+  </g>
+  <rect x="200" y="320" width="800" height="260" rx="38" fill="url(#paint0)" opacity="0.82" />
+  <rect x="240" y="360" width="300" height="180" rx="22" fill="#1A0C31" />
+  <rect x="580" y="360" width="360" height="180" rx="22" fill="#211043" />
+  <path d="M240 600H960L940 720H260L240 600Z" fill="#120821" />
+  <defs>
+    <filter id="glow1" x="640" y="-140" width="800" height="800" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="70" />
+    </filter>
+    <filter id="glow2" x="-180" y="-160" width="760" height="760" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="70" />
+    </filter>
+    <linearGradient id="paint0" x1="200" y1="320" x2="1000" y2="580" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#2D0F46" />
+      <stop offset="1" stop-color="#110721" />
+    </linearGradient>
+  </defs>
+</svg>

--- a/public/scripts/shop-detail.js
+++ b/public/scripts/shop-detail.js
@@ -1,0 +1,137 @@
+(function () {
+  const slider = document.querySelector('[data-slider]');
+  if (slider) {
+    const track = slider.querySelector('[data-slider-track]');
+    const slides = Array.from(track.children);
+    const prev = slider.querySelector('[data-slider-prev]');
+    const next = slider.querySelector('[data-slider-next]');
+    const dotsHost = slider.querySelector('[data-slider-dots]');
+    let index = 0;
+    let timer;
+
+    function updateTransform() {
+      track.style.transform = `translateX(-${index * 100}%)`;
+      if (dotsHost) {
+        const dots = dotsHost.querySelectorAll('.detail-gallery__dot');
+        dots.forEach((dot, dotIndex) => {
+          dot.setAttribute('aria-current', dotIndex === index ? 'true' : 'false');
+        });
+      }
+    }
+
+    function goToSlide(newIndex) {
+      if (!slides.length) {
+        return;
+      }
+      const total = slides.length;
+      index = (newIndex + total) % total;
+      updateTransform();
+    }
+
+    function startAuto() {
+      if (timer || slides.length < 2) {
+        return;
+      }
+      timer = window.setInterval(() => {
+        goToSlide(index + 1);
+      }, 6000);
+    }
+
+    function stopAuto() {
+      if (timer) {
+        window.clearInterval(timer);
+        timer = undefined;
+      }
+    }
+
+    if (dotsHost && slides.length > 1) {
+      const fragment = document.createDocumentFragment();
+      slides.forEach((_, dotIndex) => {
+        const dot = document.createElement('button');
+        dot.type = 'button';
+        dot.className = 'detail-gallery__dot';
+        dot.setAttribute('aria-label', `${dotIndex + 1}번 이미지 보기`);
+        dot.addEventListener('click', () => {
+          goToSlide(dotIndex);
+          stopAuto();
+          startAuto();
+        });
+        fragment.appendChild(dot);
+      });
+      dotsHost.appendChild(fragment);
+    }
+
+    if (prev) {
+      prev.addEventListener('click', () => {
+        goToSlide(index - 1);
+        stopAuto();
+        startAuto();
+      });
+    }
+
+    if (next) {
+      next.addEventListener('click', () => {
+        goToSlide(index + 1);
+        stopAuto();
+        startAuto();
+      });
+    }
+
+    slider.addEventListener('mouseenter', stopAuto);
+    slider.addEventListener('mouseleave', startAuto);
+    slider.addEventListener('touchstart', stopAuto, { passive: true });
+    slider.addEventListener('touchend', startAuto, { passive: true });
+
+    updateTransform();
+    startAuto();
+  }
+
+  const seoEditor = document.querySelector('[data-seo-editor]');
+  if (seoEditor) {
+    const textarea = seoEditor.querySelector('textarea');
+    const copyButton = seoEditor.querySelector('[data-action="copy"]');
+    const status = seoEditor.querySelector('[data-status]');
+    const metaKeywords = document.querySelector('meta[name="keywords"]');
+    let statusTimer;
+
+    if (!textarea) {
+      return;
+    }
+
+    function setStatus(message, isSuccess) {
+      if (!status) {
+        return;
+      }
+      status.textContent = message;
+      status.style.color = isSuccess ? '#ff9bd1' : 'var(--color-muted)';
+      if (statusTimer) {
+        window.clearTimeout(statusTimer);
+      }
+      if (message) {
+        statusTimer = window.setTimeout(() => {
+          status.textContent = '';
+        }, 4000);
+      }
+    }
+
+    function updateMetaKeywords() {
+      if (metaKeywords) {
+        metaKeywords.setAttribute('content', textarea.value.trim());
+      }
+    }
+
+    textarea.addEventListener('input', updateMetaKeywords);
+
+    if (copyButton) {
+      copyButton.addEventListener('click', async () => {
+        try {
+          await navigator.clipboard.writeText(textarea.value);
+          setStatus('키워드를 복사했습니다. 운영팀에 전달해 반영해주세요.', true);
+        } catch (error) {
+          console.warn('Clipboard copy failed:', error);
+          setStatus('복사에 실패했습니다. 직접 복사해주세요.', false);
+        }
+      });
+    }
+  }
+})();

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -1,12 +1,13 @@
 :root {
-  --color-bg: #07090f;
-  --color-surface: #0f1119;
-  --color-panel: #141724;
-  --color-primary: #ff496a;
-  --color-accent: #4f8cff;
-  --color-text: #f6f7fb;
-  --color-muted: #a3a9c2;
-  --color-border: rgba(255, 255, 255, 0.08);
+  --color-bg: #05030a;
+  --color-surface: #0b0616;
+  --color-panel: #130b28;
+  --color-primary: #ff2e8b;
+  --color-accent: #8f5bff;
+  --color-text: #f7f6ff;
+  --color-muted: #b1a7d6;
+  --color-border: rgba(255, 255, 255, 0.1);
+  --color-glow: rgba(255, 46, 139, 0.38);
   --max-width: 1120px;
   font-family: 'Pretendard', -apple-system, BlinkMacSystemFont, 'Segoe UI',
     'Noto Sans KR', sans-serif;
@@ -18,7 +19,9 @@
 
 body {
   margin: 0;
-  background: radial-gradient(circle at top left, #15203a, var(--color-bg) 60%);
+  background: radial-gradient(circle at 10% 10%, #1b1235, transparent 55%),
+    radial-gradient(circle at 90% 10%, rgba(143, 91, 255, 0.18), transparent 60%),
+    linear-gradient(160deg, #060312 0%, #020106 100%);
   color: var(--color-text);
   line-height: 1.6;
 }
@@ -48,9 +51,10 @@ img {
   position: sticky;
   top: 0;
   z-index: 100;
-  background: rgba(7, 9, 15, 0.92);
-  backdrop-filter: blur(16px);
+  background: rgba(5, 3, 16, 0.92);
+  backdrop-filter: blur(22px);
   border-bottom: 1px solid var(--color-border);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
 }
 
 .site-header__topbar {
@@ -82,8 +86,9 @@ img {
 .branding {
   font-size: 1.4rem;
   font-weight: 700;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
+  color: #fff;
 }
 
 .nav {
@@ -109,9 +114,9 @@ img {
 }
 
 .btn--primary {
-  background: linear-gradient(135deg, var(--color-primary), #ff7c4d);
+  background: linear-gradient(135deg, var(--color-primary), var(--color-accent));
   color: #fff;
-  box-shadow: 0 10px 20px rgba(255, 73, 106, 0.25);
+  box-shadow: 0 18px 32px rgba(255, 46, 139, 0.25);
 }
 
 .btn--ghost {
@@ -131,15 +136,17 @@ img {
 
 .hero {
   position: relative;
-  padding: 6rem 0 4rem;
+  padding: 6.5rem 0 4.5rem;
   overflow: hidden;
 }
 
 .hero__overlay {
   position: absolute;
   inset: 0;
-  background: linear-gradient(140deg, rgba(32, 44, 78, 0.8), rgba(7, 9, 15, 0.95));
-  mix-blend-mode: lighten;
+  background: radial-gradient(circle at 20% 20%, rgba(255, 46, 139, 0.28), transparent 60%),
+    radial-gradient(circle at 80% 0%, rgba(143, 91, 255, 0.25), transparent 55%),
+    linear-gradient(140deg, rgba(18, 9, 33, 0.95), rgba(5, 3, 16, 0.95));
+  mix-blend-mode: screen;
   pointer-events: none;
 }
 
@@ -157,10 +164,12 @@ img {
   gap: 0.5rem;
   padding: 0.45rem 1rem;
   border-radius: 999px;
-  background: rgba(79, 140, 255, 0.18);
-  color: #9cc1ff;
+  background: rgba(255, 46, 139, 0.18);
+  color: #ff9bd1;
   font-weight: 600;
   font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
 }
 
 .hero__text h1 {
@@ -282,10 +291,11 @@ img {
 }
 
 .feature-card {
-  background: rgba(7, 9, 15, 0.75);
+  background: rgba(10, 6, 24, 0.85);
   padding: 1.75rem;
   border-radius: 18px;
   border: 1px solid var(--color-border);
+  box-shadow: 0 18px 30px rgba(5, 0, 20, 0.45);
 }
 
 .feature-card h3 {
@@ -308,13 +318,14 @@ img {
 }
 
 .shop-card {
-  background: rgba(15, 17, 25, 0.8);
+  background: rgba(8, 5, 18, 0.78);
   border-radius: 20px;
   overflow: hidden;
-  border: 1px solid var(--color-border);
+  border: 1px solid rgba(255, 255, 255, 0.08);
   display: flex;
   flex-direction: column;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 20px 36px rgba(5, 0, 20, 0.45);
 }
 
 .shop-card:hover {
@@ -368,70 +379,216 @@ img {
 }
 
 .detail-hero {
-  padding: 6rem 0 3rem;
+  padding: 6.5rem 0 3.5rem;
 }
 
-.detail-hero__content {
+.detail-hero__grid {
   display: grid;
   gap: 2.5rem;
   align-items: center;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
 }
 
-.detail-hero__image img {
+.detail-gallery {
+  position: relative;
+  overflow: hidden;
+  border-radius: 28px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(8, 5, 18, 0.8);
+  box-shadow: 0 25px 48px rgba(5, 0, 20, 0.55);
+  aspect-ratio: 4 / 3;
+}
+
+.detail-gallery::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(160deg, rgba(255, 46, 139, 0.08), transparent 55%),
+    linear-gradient(-160deg, rgba(143, 91, 255, 0.08), transparent 45%);
+  pointer-events: none;
+}
+
+.detail-gallery__track {
+  display: flex;
+  transition: transform 0.6s ease;
+}
+
+.detail-gallery__slide {
+  flex: 0 0 100%;
+  position: relative;
+}
+
+.detail-gallery__slide img {
   width: 100%;
-  border-radius: 24px;
-  border: 1px solid var(--color-border);
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.detail-gallery__control {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  background: rgba(5, 3, 16, 0.55);
+  backdrop-filter: blur(8px);
+  cursor: pointer;
+  transition: background 0.3s ease, border-color 0.3s ease, transform 0.3s ease;
+}
+
+.detail-gallery__control::before {
+  content: '';
+  display: block;
+  width: 12px;
+  height: 12px;
+  border-top: 2px solid #fff;
+  border-right: 2px solid #fff;
+  margin: auto;
+  transform: rotate(45deg);
+}
+
+.detail-gallery__control--prev {
+  left: 1rem;
+}
+
+.detail-gallery__control--prev::before {
+  transform: rotate(-135deg);
+}
+
+.detail-gallery__control--next {
+  right: 1rem;
+}
+
+.detail-gallery__control:hover {
+  background: rgba(255, 46, 139, 0.35);
+  border-color: rgba(255, 255, 255, 0.6);
+  transform: translateY(-50%) scale(1.05);
+}
+
+.detail-gallery__dots {
+  position: absolute;
+  bottom: 1.25rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 0.5rem;
+  z-index: 2;
+}
+
+.detail-gallery__dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  background: rgba(5, 3, 16, 0.6);
+  transition: transform 0.3s ease, background 0.3s ease;
+}
+
+.detail-gallery__dot[aria-current='true'] {
+  background: var(--color-primary);
+  transform: scale(1.2);
 }
 
 .detail-hero__meta {
   color: var(--color-muted);
   text-transform: uppercase;
-  letter-spacing: 0.12em;
+  letter-spacing: 0.18em;
+  font-size: 0.8rem;
+}
+
+.detail-hero__info h1 {
+  font-size: clamp(2rem, 2.2vw + 1.5rem, 3rem);
+  margin: 0.75rem 0 1.25rem;
 }
 
 .detail-hero__description {
   color: var(--color-muted);
-  margin-bottom: 1.5rem;
+  margin-bottom: 1.75rem;
 }
 
 .detail-hero__list {
   display: grid;
-  gap: 0.75rem;
+  gap: 1.1rem;
   margin-bottom: 2rem;
 }
 
 .detail-hero__list dt {
   font-weight: 600;
   color: var(--color-muted);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
 }
 
 .detail-hero__list dd {
-  margin: 0;
+  margin: 0.25rem 0 0;
+  font-size: 1.05rem;
 }
+
 .detail-hero__manager-contact {
   display: block;
-  margin-top: 0.25rem;
+  margin-top: 0.35rem;
   color: var(--color-muted);
 }
+
 .detail-hero__manager-contact a {
   color: inherit;
   font-weight: 600;
 }
 
-.highlight-list {
+.detail-hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}
+
+.detail-hero__actions .back-link {
+  font-weight: 500;
+  color: var(--color-muted);
+}
+
+.detail-section {
+  padding-top: 0;
+}
+
+.detail-section__grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.detail-card {
+  background: rgba(10, 6, 24, 0.85);
+  border-radius: 22px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 2rem;
+  box-shadow: 0 22px 44px rgba(5, 0, 20, 0.5);
+}
+
+.detail-card h2 {
+  margin-top: 0;
+  margin-bottom: 1.5rem;
+}
+
+.detail-tags {
   list-style: none;
   padding: 0;
   margin: 0;
-  display: grid;
+  display: flex;
+  flex-wrap: wrap;
   gap: 0.75rem;
 }
 
-.highlight-list li {
-  padding: 1rem 1.25rem;
-  background: rgba(15, 17, 25, 0.75);
-  border-radius: 14px;
-  border: 1px solid var(--color-border);
+.detail-tags li {
+  padding: 0.55rem 1.1rem;
+  border-radius: 999px;
+  background: rgba(255, 46, 139, 0.16);
+  color: #ffd4eb;
+  font-weight: 600;
 }
 .pricing-grid {
   display: grid;
@@ -439,11 +596,12 @@ img {
   gap: 1.5rem;
 }
 .pricing-card {
-  background: rgba(15, 17, 25, 0.8);
+  background: rgba(5, 3, 16, 0.8);
   border-radius: 18px;
-  border: 1px solid var(--color-border);
+  border: 1px solid rgba(255, 255, 255, 0.08);
   padding: 1.75rem;
   text-align: center;
+  box-shadow: inset 0 0 0 1px rgba(255, 46, 139, 0.12);
 }
 .pricing-card h3 {
   margin-top: 0;
@@ -455,10 +613,10 @@ img {
   font-weight: 500;
 }
 .contact-card {
-  background: rgba(7, 9, 15, 0.7);
-  border-radius: 20px;
-  border: 1px solid var(--color-border);
-  padding: 2rem;
+  background: rgba(5, 3, 16, 0.78);
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 1.75rem;
 }
 .contact-card ul {
   list-style: none;
@@ -474,6 +632,105 @@ img {
   color: inherit;
   font-weight: 600;
 }
+
+.detail-seo__grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: start;
+}
+
+.detail-seo__description {
+  color: var(--color-muted);
+  margin-bottom: 1.5rem;
+}
+
+.seo-chip-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.seo-chip-list li {
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  background: rgba(143, 91, 255, 0.16);
+  color: #d6c9ff;
+  font-weight: 600;
+}
+
+.seo-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  background: rgba(5, 3, 16, 0.85);
+  border-radius: 18px;
+  padding: 1.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 20px 38px rgba(5, 0, 20, 0.45);
+}
+
+.seo-editor label {
+  font-weight: 600;
+  color: var(--color-muted);
+}
+
+.seo-editor textarea {
+  width: 100%;
+  background: rgba(8, 5, 18, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 14px;
+  padding: 1rem;
+  color: var(--color-text);
+  resize: vertical;
+  min-height: 160px;
+  font-family: inherit;
+}
+
+.seo-editor textarea:focus {
+  outline: 2px solid rgba(255, 46, 139, 0.4);
+}
+
+.seo-editor__actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.seo-editor__status {
+  font-size: 0.85rem;
+  color: var(--color-muted);
+  min-height: 1rem;
+}
+
+@media (max-width: 768px) {
+  .hero__container {
+    gap: 2rem;
+  }
+
+  .detail-gallery {
+    aspect-ratio: 16 / 12;
+  }
+
+  .detail-gallery__control {
+    display: none;
+  }
+
+  .detail-hero__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .detail-hero__actions .btn {
+    width: 100%;
+    justify-content: center;
+  }
+}
 .seo-keywords {
   display: none;
 }
@@ -487,7 +744,9 @@ img {
 }
 
 .section--muted {
-  background: rgba(15, 17, 25, 0.55);
+  background: rgba(8, 5, 18, 0.75);
+  border-top: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .category-chips {
@@ -499,8 +758,8 @@ img {
 .category-chip {
   padding: 0.6rem 1.2rem;
   border-radius: 999px;
-  background: rgba(79, 140, 255, 0.16);
-  color: #a9c8ff;
+  background: rgba(143, 91, 255, 0.18);
+  color: #cfbbff;
   font-weight: 600;
 }
 

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -1,13 +1,13 @@
-<%- include('partials/head', { title: 'Room Guide - 프리미엄 유흥 업소 가이드', seoKeywords }) %>
+<%- include('partials/head', { title: '룸빵일번지 - 프리미엄 유흥 공간 가이드', seoKeywords }) %>
   <section class="hero">
     <div class="hero__overlay"></div>
     <div class="container hero__container">
       <div class="hero__text">
-        <span class="badge">서울 · 부산 프리미엄 라운지 큐레이션</span>
-        <h1>검증된 룸과 클럽을 한곳에서, Room Guide</h1>
+        <span class="badge">서울 · 수도권 · 부산 프리미엄 큐레이션</span>
+        <h1>강남부터 해운대까지, 룸빵일번지가 추천하는 야간 핫플</h1>
         <p>
-          지역 → 구 → 업종 순으로 정교하게 나뉜 필터를 활용하면 맞춤형 제휴업체를 바로 확인할 수 있습니다.
-          모든 파트너는 직접 검수한 신뢰도 높은 공간입니다.
+          지역 → 구 → 업종 순으로 세분화된 필터를 활용해 원하는 무드의 공간을 바로 찾아보세요.
+          모든 파트너는 룸빵일번지 전문 매칭팀이 직접 검증한 곳만 소개합니다.
         </p>
         <div class="hero__search">
           <div class="hero__filters">
@@ -40,7 +40,7 @@
         </div>
         <ul class="hero__highlights">
           <li>실시간 예약 문의 연계</li>
-          <li>전담 매니저 배정</li>
+          <li>전담 컨시어지 배정</li>
           <li>VIP 맞춤 코스 추천</li>
         </ul>
       </div>
@@ -64,7 +64,7 @@
   <section class="section section--intro">
     <div class="container section__container">
       <div>
-        <h2 class="section__title">Room Guide와 함께하는 프리미엄 나이트 라이프</h2>
+        <h2 class="section__title">룸빵일번지와 함께 즐기는 하이엔드 나이트 라이프</h2>
         <p class="section__subtitle">
           트렌디한 라운지부터 하이엔드 클럽까지, 취향에 맞춘 업소를 전문가가 직접 추천해드립니다.
         </p>
@@ -72,15 +72,15 @@
       <div class="feature-grid">
         <div class="feature-card">
           <h3>믿을 수 있는 검수</h3>
-          <p>모든 제휴처는 2단계 검증을 거쳐 등록되며, 예약 품질을 지속적으로 모니터링합니다.</p>
+          <p>모든 제휴 파트너는 2단계 현장 검증을 거쳐 등록되며, 예약 품질을 상시 모니터링합니다.</p>
         </div>
         <div class="feature-card">
           <h3>실시간 상담</h3>
-          <p>카카오톡 · 전화 상담을 통해 원하는 시간과 인원에 맞춘 맞춤 코스를 제안합니다.</p>
+          <p>카카오톡 · 전화 상담으로 원하는 시간과 인원에 맞춘 맞춤 코스를 제안합니다.</p>
         </div>
         <div class="feature-card">
           <h3>다양한 혜택</h3>
-          <p>Room Guide 회원만을 위한 특별 할인, 전용 룸 업그레이드 혜택을 제공해드립니다.</p>
+          <p>룸빵일번지 회원만을 위한 특별 할인과 전용 룸 업그레이드 혜택을 제공해드립니다.</p>
         </div>
       </div>
     </div>
@@ -142,13 +142,13 @@
         </div>
         <div class="step-card">
           <span class="step-card__number">02</span>
-          <h3>상담 매니저 연결</h3>
-          <p>상담 버튼을 통해 전담 매니저와 바로 연결되어 일정과 혜택을 확인합니다.</p>
+          <h3>전담 컨시어지 연결</h3>
+          <p>상담 버튼으로 연결되는 전담 컨시어지가 일정과 혜택을 세심하게 안내합니다.</p>
         </div>
         <div class="step-card">
           <span class="step-card__number">03</span>
           <h3>예약 및 방문</h3>
-          <p>예약이 확정되면 전용 혜택과 함께 즐거운 시간을 보낼 수 있도록 안내합니다.</p>
+          <p>예약이 확정되면 전용 혜택과 함께 완벽한 밤을 즐길 수 있도록 안내합니다.</p>
         </div>
       </div>
     </div>
@@ -158,7 +158,7 @@
     <div class="container section--cta__content">
       <div>
         <h2 class="section__title">제휴 파트너가 되어보세요</h2>
-        <p class="section__subtitle">Room Guide 네트워크에 합류하여 더 많은 프리미엄 고객을 만나보세요.</p>
+        <p class="section__subtitle">룸빵일번지 네트워크에 합류하여 더 많은 프리미엄 고객을 만나보세요.</p>
       </div>
       <a class="btn btn--primary btn--large" href="tel:01000000000">제휴 상담 바로 연결</a>
     </div>

--- a/views/partials/footer.ejs
+++ b/views/partials/footer.ejs
@@ -2,15 +2,15 @@
     <footer class="site-footer" id="consult">
       <div class="container site-footer__content">
         <div>
-          <h3>Room Guide</h3>
-          <p>강남 · 경기권 프리미엄 라운지와 클럽을 검증된 파트너 네트워크로 연결해드립니다.</p>
+          <h3>룸빵일번지</h3>
+          <p>강남 · 수도권 · 부산의 프리미엄 룸과 라운지를 연결하는 원스톱 컨시어지 플랫폼입니다.</p>
         </div>
         <div>
           <h4>상담 안내</h4>
           <ul>
             <li>제휴 문의: <a href="tel:01000000000">010-0000-0000</a></li>
             <li>운영 시간: 12:00 ~ 03:00</li>
-            <li>카카오톡: @roomguide</li>
+            <li>카카오톡: @roombbang1st</li>
           </ul>
         </div>
         <div>
@@ -23,7 +23,7 @@
         </div>
       </div>
       <div class="site-footer__bottom">
-        <p>© <%= new Date().getFullYear() %> Room Guide. All rights reserved.</p>
+        <p>© <%= new Date().getFullYear() %> 룸빵일번지. All rights reserved.</p>
       </div>
     </footer>
     <% if (scripts) { %>

--- a/views/partials/head.ejs
+++ b/views/partials/head.ejs
@@ -19,7 +19,7 @@
     <header class="site-header">
       <div class="site-header__topbar">
         <div class="container">
-          <span>서울 · 경기 프리미엄 룸 네트워크</span>
+          <span>프리미엄 룸 · 라운지 컨시어지 플랫폼</span>
           <div class="topbar__links">
             <a href="#consult">제휴 문의</a>
             <a href="tel:01000000000">고객센터 010-0000-0000</a>
@@ -27,11 +27,11 @@
         </div>
       </div>
       <div class="container site-header__main">
-        <a class="branding" href="/">Room Guide</a>
+        <a class="branding" href="/">룸빵일번지</a>
         <nav class="nav">
           <a href="#areas">추천 지역</a>
           <a href="#categories">업종별 찾기</a>
-          <a href="#process">이용 방법</a>
+          <a href="#process">진행 절차</a>
           <a href="#consult">제휴 안내</a>
         </nav>
         <div class="header-actions">

--- a/views/shop.ejs
+++ b/views/shop.ejs
@@ -1,8 +1,33 @@
-<%- include('partials/head', { title: shop.name + ' - Room Guide', seoKeywords }) %>
+<% const galleryImages = Array.isArray(shop.gallery) && shop.gallery.length ? shop.gallery : [{ src: shop.image, alt: shop.name + ' 분위기' }]; %>
+<%- include('partials/head', { title: shop.name + ' - 룸빵일번지', seoKeywords }) %>
   <section class="detail-hero">
-    <div class="container detail-hero__content">
-      <div class="detail-hero__image">
-        <img src="<%= shop.image %>" alt="<%= shop.name %>" />
+    <div class="container detail-hero__grid">
+      <div class="detail-gallery" data-slider>
+        <div class="detail-gallery__track" data-slider-track>
+          <% galleryImages.forEach(function(image) {
+               const source = typeof image === 'string' ? image : image.src;
+               const altText = typeof image === 'string' ? shop.name + ' 분위기' : (image.alt || shop.name + ' 분위기');
+          %>
+            <figure class="detail-gallery__slide">
+              <img src="<%= source %>" alt="<%= altText %>" />
+            </figure>
+          <% }) %>
+        </div>
+        <% if (galleryImages.length > 1) { %>
+          <button
+            class="detail-gallery__control detail-gallery__control--prev"
+            type="button"
+            aria-label="이전 이미지"
+            data-slider-prev
+          ></button>
+          <button
+            class="detail-gallery__control detail-gallery__control--next"
+            type="button"
+            aria-label="다음 이미지"
+            data-slider-next
+          ></button>
+          <div class="detail-gallery__dots" data-slider-dots></div>
+        <% } %>
       </div>
       <div class="detail-hero__info">
         <p class="detail-hero__meta"><%= shop.region %> · <%= shop.district %> · <%= shop.category %></p>
@@ -34,59 +59,83 @@
             <dd><%= shop.hours %></dd>
           </div>
         </dl>
-        <a class="back-link" href="/">← 메인으로 돌아가기</a>
-      </div>
-    </div>
-  </section>
-
-  <section class="section">
-    <div class="container">
-      <h2>요금 안내</h2>
-      <div class="pricing-grid">
-        <div class="pricing-card">
-          <h3>주대</h3>
-          <p><%= shop.pricing.base %></p>
-        </div>
-        <div class="pricing-card">
-          <h3>TC</h3>
-          <p><%= shop.pricing.tc %></p>
-        </div>
-        <div class="pricing-card">
-          <h3>RT</h3>
-          <p><%= shop.pricing.rt %></p>
+        <div class="detail-hero__actions">
+          <a class="btn btn--primary" href="tel:<%= shop.manager.phone %>">즉시 전화 상담</a>
+          <a class="back-link" href="/">메인으로 돌아가기</a>
         </div>
       </div>
     </div>
   </section>
 
-  <section class="section section--muted">
-    <div class="container">
-      <h2>담당자 상담 채널</h2>
-      <div class="contact-card">
-        <p>전담 매니저가 예약, 혜택, 행사 문의를 실시간으로 응대해드립니다.</p>
-        <ul>
-          <li><strong>담당자</strong> <%= shop.manager.name %></li>
-          <li><strong>연락처</strong> <a href="tel:<%= shop.manager.phone %>"><%= shop.manager.phone %></a></li>
-          <% if (shop.manager.kakao) { %>
-            <li><strong>카카오톡</strong> <%= shop.manager.kakao %></li>
-          <% } %>
+  <section class="section detail-section">
+    <div class="container detail-section__grid">
+      <div class="detail-card">
+        <h2>요금 안내</h2>
+        <div class="pricing-grid">
+          <div class="pricing-card">
+            <h3>주대</h3>
+            <p><%= shop.pricing.base %></p>
+          </div>
+          <div class="pricing-card">
+            <h3>TC</h3>
+            <p><%= shop.pricing.tc %></p>
+          </div>
+          <div class="pricing-card">
+            <h3>RT</h3>
+            <p><%= shop.pricing.rt %></p>
+          </div>
+        </div>
+      </div>
+      <div class="detail-card">
+        <h2>담당자 상담 채널</h2>
+        <div class="contact-card">
+          <p>전담 매니저가 예약, 혜택, 행사 문의를 실시간으로 응대해드립니다.</p>
+          <ul>
+            <li><strong>담당자</strong> <%= shop.manager.name %></li>
+            <li><strong>연락처</strong> <a href="tel:<%= shop.manager.phone %>"><%= shop.manager.phone %></a></li>
+            <% if (shop.manager.kakao) { %>
+              <li><strong>카카오톡</strong> <%= shop.manager.kakao %></li>
+            <% } %>
+          </ul>
+        </div>
+      </div>
+      <div class="detail-card">
+        <h2>핵심 포인트</h2>
+        <ul class="detail-tags">
+          <% shop.highlights.forEach(function(item) { %>
+            <li><%= item %></li>
+          <% }) %>
         </ul>
       </div>
     </div>
   </section>
 
-  <section class="section">
-    <div class="container">
-      <h2>핵심 포인트</h2>
-      <ul class="highlight-list">
-        <% shop.highlights.forEach(function(item) { %>
-          <li><%= item %></li>
-        <% }) %>
-      </ul>
+  <section class="section section--muted detail-seo">
+    <div class="container detail-seo__grid">
+      <div>
+        <h2>SEO 키워드 프리셋</h2>
+        <p class="detail-seo__description">
+          현재 등록된 키워드는 검색 노출 향상을 위해 메타 태그로 자동 반영됩니다. 필요에 따라 아래
+          편집기를 활용해 키워드를 다듬고, 저장을 위해 운영팀에 전달하세요.
+        </p>
+        <ul class="seo-chip-list">
+          <% (seoKeywords || []).forEach(function(keyword) { %>
+            <li><%= keyword %></li>
+          <% }) %>
+        </ul>
+      </div>
+      <form class="seo-editor" data-seo-editor>
+        <label for="seo-keywords-input">키워드 작성</label>
+        <textarea id="seo-keywords-input" rows="6"><%= (seoKeywords || []).join(', ') %></textarea>
+        <div class="seo-editor__actions">
+          <button type="button" class="btn btn--ghost" data-action="copy">키워드 복사</button>
+          <span class="seo-editor__status" data-status role="status" aria-live="polite"></span>
+        </div>
+      </form>
     </div>
   </section>
 
   <div class="seo-keywords" aria-hidden="true">
     <%- (seoKeywords || []).join(', ') %>
   </div>
-<%- include('partials/footer') %>
+<%- include('partials/footer', { scripts: ['/scripts/shop-detail.js'] }) %>


### PR DESCRIPTION
## Summary
- Rebrand the layout copy and header/footer to the 룸빵일번지 identity and refresh the neon nightlife styling
- Expand shop detail pages with an auto-sliding gallery, concierge CTA, and an SEO keyword editor widget
- Add supporting gallery artwork assets, new client-side slider script, and ignore node_modules via .gitignore

## Testing
- node -e "require('./data/shops.json'); console.log('ok');"


------
https://chatgpt.com/codex/tasks/task_e_68e42a0ce08c832591ea3b15ff3c90ad