### PR TITLE
Add custom roompang branding assets

### DIFF
--- a/public/images/favicon-roompang.svg
+++ b/public/images/favicon-roompang.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-labelledby="title desc">
+  <title id="title">룸빵일번지 파비콘</title>
+  <desc id="desc">빨간색 미소를 띤 병 모양 아이콘</desc>
+  <rect width="256" height="256" rx="56" fill="#ffffff" />
+  <g fill="#f24b2c">
+    <path d="M88 36a12 12 0 0 1 12-12h56a12 12 0 0 1 12 12v48h8a20 20 0 0 1 20 20v96c0 35.35-28.65 64-64 64h-8c-35.35 0-64-28.65-64-64v-96a20 20 0 0 1 20-20h8z" />
+    <circle cx="112" cy="140" r="12" fill="#ffffff" />
+    <circle cx="144" cy="140" r="12" fill="#ffffff" />
+    <path d="M96 188c16 20 48 20 64 0" stroke="#ffffff" stroke-width="12" stroke-linecap="round" fill="none" />
+  </g>
+</svg>

--- a/public/images/logo-roompang.svg
+++ b/public/images/logo-roompang.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">룸빵일번지 로고</title>
+  <desc id="desc">빨강, 파랑, 초록의 문자로 구성된 No.1 roompang 텍스트 로고</desc>
+  <rect width="512" height="512" fill="#ffffff" rx="56" />
+  <g font-family="'Pretendard', 'Noto Sans KR', 'Segoe UI', sans-serif" font-weight="700">
+    <text x="50%" y="212" font-size="164" text-anchor="middle" fill="#d13c25">No</text>
+    <text x="270" y="212" font-size="164" fill="#0092ff">.1</text>
+    <text x="50%" y="356" font-size="124" text-anchor="middle" letter-spacing="4" fill="#4c1f1f">room</text>
+    <text x="352" y="356" font-size="124" fill="#1fa04c">pang</text>
+  </g>
+</svg>

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -84,11 +84,28 @@ img {
 }
 
 .branding {
-  font-size: 1.4rem;
-  font-weight: 700;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
   color: #fff;
+}
+
+.branding img {
+  height: 44px;
+  width: auto;
+  filter: drop-shadow(0 6px 18px rgba(0, 0, 0, 0.35));
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .nav {

--- a/views/partials/head.ejs
+++ b/views/partials/head.ejs
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title><%= title %></title>
+    <link rel="icon" type="image/svg+xml" href="/images/favicon-roompang.svg" />
+    <link rel="apple-touch-icon" href="/images/favicon-roompang.svg" />
     <% if (seoKeywords && seoKeywords.length) { %>
       <meta name="keywords" content="<%= seoKeywords.join(', ') %>" />
     <% } %>
@@ -27,7 +29,10 @@
         </div>
       </div>
       <div class="container site-header__main">
-        <a class="branding" href="/">룸빵일번지</a>
+        <a class="branding" href="/">
+          <img src="/images/logo-roompang.svg" alt="룸빵일번지 로고" />
+          <span class="sr-only">룸빵일번지 홈으로 이동</span>
+        </a>
         <nav class="nav">
           <a href="#areas">추천 지역</a>
           <a href="#categories">업종별 찾기</a>


### PR DESCRIPTION
## Summary
- add SVG assets for the roompang logo and favicon
- update the header markup to render the new logo and expose favicon metadata
- tweak branding styles and add an accessible sr-only helper for screen readers

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68e4428e72648325ac2c6dd176adafe1