### PR TITLE
Add multilingual support and SEO enhancements

### DIFF
--- a/data/shops.json
+++ b/data/shops.json
@@ -44,7 +44,53 @@
       "강남 VIP 룸",
       "서울 라운지 추천"
     ],
-    "image": "/images/gangnam-lounge-101.svg"
+    "image": "/images/gangnam-lounge-101.svg",
+    "translations": {
+      "en": {
+        "name": "Running Rabbit Lounge",
+        "address": "604-11 Yeoksam-dong, Gangnam-gu, Seoul",
+        "hours": "Daily 18:00 – 04:00",
+        "description": "A premium lounge celebrated for its sensory mood and signature cocktails crafted by expert bartenders.",
+        "highlights": [
+          "Handcrafted signature cocktails",
+          "DJ lounge performances",
+          "Private VIP rooms"
+        ],
+        "pricing": {
+          "base": "From 130,000 KRW",
+          "tc": "TC from 120,000",
+          "rt": "RT from 50,000"
+        },
+        "seoKeywords": [
+          "Gangnam lounge",
+          "Gangnam premium bar",
+          "Gangnam VIP room",
+          "Seoul lounge picks"
+        ]
+      },
+      "zh": {
+        "name": "奔兔酒廊",
+        "address": "首爾市江南區驛三洞 604-11",
+        "hours": "每日 18:00 – 04:00",
+        "description": "以感官氛圍與專業調酒師的招牌特調著稱的精品酒廊。",
+        "highlights": [
+          "手工招牌調酒",
+          "DJ 酒廊表演",
+          "私密 VIP 包廂"
+        ],
+        "pricing": {
+          "base": "最低 13 萬韓元起",
+          "tc": "TC 12 萬起",
+          "rt": "RT 5 萬起"
+        },
+        "seoKeywords": [
+          "江南酒廊",
+          "江南精品酒吧",
+          "江南 VIP 包廂",
+          "首爾酒廊推薦"
+        ]
+      }
+    }
   },
   {
     "id": "seoul-gwanak-premium-room",
@@ -91,7 +137,53 @@
       "관악 주대 정보",
       "비즈니스 접대 장소"
     ],
-    "image": "/images/gwanak-premium-room.svg"
+    "image": "/images/gwanak-premium-room.svg",
+    "translations": {
+      "en": {
+        "name": "Gwanak Premium Room",
+        "address": "325 Bongcheon-ro, Gwanak-gu, Seoul",
+        "hours": "Mon–Sat 18:00 – 03:00",
+        "description": "A high-end salon optimized for loyal business clients with private rooms and bespoke table settings.",
+        "highlights": [
+          "On-site dedicated manager",
+          "Business-tailored courses",
+          "Valet parking service"
+        ],
+        "pricing": {
+          "base": "Weekday from mid 450,000 KRW · Weekend from mid 550,000 KRW",
+          "tc": "TC from 100,000",
+          "rt": "RT from 350,000"
+        },
+        "seoKeywords": [
+          "Gwanak room salon",
+          "Seoul Gwanak nightlife",
+          "Gwanak table charge",
+          "Business hosting venue"
+        ]
+      },
+      "zh": {
+        "name": "冠岳精品包廂",
+        "address": "首爾市冠岳區奉天路 325",
+        "hours": "週一至週六 18:00 – 03:00",
+        "description": "為商務常客量身打造的高端包廂沙龍，提供私密空間與客製桌邊服務。",
+        "highlights": [
+          "專屬經理常駐",
+          "商務客製行程",
+          "代客泊車服務"
+        ],
+        "pricing": {
+          "base": "平日 45 萬韓元起・週末 55 萬韓元起",
+          "tc": "TC 10 萬起",
+          "rt": "RT 35 萬起"
+        },
+        "seoKeywords": [
+          "冠岳包廂",
+          "首爾冠岳夜生活",
+          "冠岳桌費資訊",
+          "商務招待場所"
+        ]
+      }
+    }
   },
   {
     "id": "seoul-gangseo-night-suite",
@@ -138,7 +230,53 @@
       "서울 강서 유흥",
       "강서 나이트 예약"
     ],
-    "image": "/images/gangseo-night-suite.svg"
+    "image": "/images/gangseo-night-suite.svg",
+    "translations": {
+      "en": {
+        "name": "Gangseo Night Suite",
+        "address": "512 Magok-dong, Gangseo-gu, Seoul",
+        "hours": "Daily 19:00 – 05:00",
+        "description": "A high-end bar featuring dual spaces with a rooftop so you can enjoy distinct moods all year round.",
+        "highlights": [
+          "Four-season rooftop",
+          "Premium whisky selection",
+          "Artist live sessions"
+        ],
+        "pricing": {
+          "base": "Weekday from mid 400,000 KRW · Weekend from mid 500,000 KRW",
+          "tc": "TC from 90,000",
+          "rt": "RT from 320,000"
+        },
+        "seoKeywords": [
+          "Gangseo high-end bar",
+          "Magok rooftop bar",
+          "Seoul Gangseo nightlife",
+          "Gangseo night reservation"
+        ]
+      },
+      "zh": {
+        "name": "江西夜間套房",
+        "address": "首爾市江西區麻谷洞 512",
+        "hours": "每日 19:00 – 05:00",
+        "description": "擁有雙層空間並結合屋頂露台，一年四季都能享受不同氛圍的精品酒吧。",
+        "highlights": [
+          "四季皆宜的屋頂露台",
+          "精選頂級威士忌",
+          "駐店音樂人現場演出"
+        ],
+        "pricing": {
+          "base": "平日 40 萬韓元起・週末 50 萬韓元起",
+          "tc": "TC 9 萬起",
+          "rt": "RT 32 萬起"
+        },
+        "seoKeywords": [
+          "江西精品酒吧",
+          "麻谷屋頂酒吧",
+          "首爾江西夜生活",
+          "江西夜店預約"
+        ]
+      }
+    }
   },
   {
     "id": "busan-haeundae-ocean-lounge",
@@ -185,7 +323,53 @@
       "해운대 주대",
       "부산 프리미엄 라운지"
     ],
-    "image": "/images/haeundae-ocean-lounge.svg"
+    "image": "/images/haeundae-ocean-lounge.svg",
+    "translations": {
+      "en": {
+        "name": "Haeundae Ocean Lounge",
+        "address": "72 Dalmaji-gil, Haeundae-gu, Busan",
+        "hours": "Daily 17:00 – 03:00",
+        "description": "An ocean-view lounge where curated wine and whisky pairings meet sweeping views of Busan Bay.",
+        "highlights": [
+          "Ocean view from every room",
+          "Sommelier-led pairings",
+          "Live yacht coordination"
+        ],
+        "pricing": {
+          "base": "Weekday from mid 350,000 KRW · Weekend from mid 450,000 KRW",
+          "tc": "TC from 80,000",
+          "rt": "RT from 280,000"
+        },
+        "seoKeywords": [
+          "Haeundae lounge",
+          "Busan ocean view bar",
+          "Haeundae table charge",
+          "Busan premium lounge"
+        ]
+      },
+      "zh": {
+        "name": "海雲臺海景酒廊",
+        "address": "釜山市海雲臺區達馬路 72",
+        "hours": "每日 17:00 – 03:00",
+        "description": "擁有釜山海景，可搭配葡萄酒與威士忌品飲的海景酒廊。",
+        "highlights": [
+          "全區域海景視野",
+          "侍酒師專業搭配",
+          "即時遊艇串聯"
+        ],
+        "pricing": {
+          "base": "平日 35 萬韓元起・週末 45 萬韓元起",
+          "tc": "TC 8 萬起",
+          "rt": "RT 28 萬起"
+        },
+        "seoKeywords": [
+          "海雲臺酒廊",
+          "釜山海景酒吧",
+          "海雲臺桌費",
+          "釜山精品酒廊"
+        ]
+      }
+    }
   },
   {
     "id": "busan-seomyeon-velvet-club",
@@ -232,6 +416,52 @@
       "부산 클럽 주대",
       "부산 EDM 클럽"
     ],
-    "image": "/images/seomyeon-velvet-club.svg"
+    "image": "/images/seomyeon-velvet-club.svg",
+    "translations": {
+      "en": {
+        "name": "Seomyeon Velvet Club",
+        "address": "686 Jungang-daero, Busanjin-gu, Busan",
+        "hours": "Fri–Sun 20:00 – 06:00",
+        "description": "Busan's signature premium club famed for cutting-edge EDM sound and immersive lighting.",
+        "highlights": [
+          "Resident superstar DJs",
+          "VIP-exclusive booths",
+          "Birthday party packages"
+        ],
+        "pricing": {
+          "base": "Weekend from mid 550,000 KRW",
+          "tc": "TC from 110,000",
+          "rt": "RT from 360,000"
+        },
+        "seoKeywords": [
+          "Busan Seomyeon club",
+          "Seomyeon premium club",
+          "Busan club table charge",
+          "Busan EDM club"
+        ]
+      },
+      "zh": {
+        "name": "西面天鵝絨夜店",
+        "address": "釜山市釜山鎮區中央大路 686",
+        "hours": "週五至週日 20:00 – 06:00",
+        "description": "以最新 EDM 聲光與高級燈光效果著稱的釜山代表性精品夜店。",
+        "highlights": [
+          "知名 DJ 常駐",
+          "VIP 專屬包廂",
+          "生日派對方案"
+        ],
+        "pricing": {
+          "base": "週末 55 萬韓元起",
+          "tc": "TC 11 萬起",
+          "rt": "RT 36 萬起"
+        },
+        "seoKeywords": [
+          "釜山西面夜店",
+          "西面精品夜店",
+          "釜山夜店桌費",
+          "釜山 EDM 夜店"
+        ]
+      }
+    }
   }
 ]

--- a/data/translations.json
+++ b/data/translations.json
@@ -1,0 +1,482 @@
+{
+  "ko": {
+    "languageCode": "ko",
+    "languageName": "한국어",
+    "meta": {
+      "siteName": "룸빵일번지",
+      "defaultTitle": "룸빵일번지",
+      "indexTitle": "룸빵일번지 - 프리미엄 유흥 공간 가이드",
+      "description": "서울, 수도권, 부산의 프리미엄 룸과 라운지를 검증된 컨시어지가 직접 큐레이션해드립니다.",
+      "shopTitleSuffix": " - 룸빵일번지"
+    },
+    "header": {
+      "tagline": "프리미엄 룸 · 라운지 컨시어지 플랫폼",
+      "affiliate": "제휴 문의",
+      "support": "고객센터 010-0000-0000",
+      "nav": {
+        "areas": "추천 지역",
+        "categories": "업종별 찾기",
+        "process": "진행 절차",
+        "consult": "제휴 안내"
+      },
+      "browseCta": "바로 둘러보기",
+      "consultCta": "빠른 상담",
+      "languageLabel": "언어"
+    },
+    "hero": {
+      "badge": "서울 · 수도권 · 부산 프리미엄 큐레이션",
+      "headline": "강남부터 해운대까지, 룸빵일번지가 추천하는 야간 핫플",
+      "description": "지역 → 구 → 업종 순으로 세분화된 필터를 활용해 원하는 무드의 공간을 바로 찾아보세요. 모든 파트너는 룸빵일번지 전문 매칭팀이 직접 검증한 곳만 소개합니다.",
+      "filters": {
+        "region": "지역",
+        "district": "구 / 군",
+        "category": "업종",
+        "all": "전체",
+        "action": "검색하기"
+      },
+      "highlights": [
+        "실시간 예약 문의 연계",
+        "전담 컨시어지 배정",
+        "VIP 맞춤 코스 추천"
+      ],
+      "stats": {
+        "shops": "제휴된 프리미엄 매장",
+        "response": "365일 빠른 응대",
+        "concierge": "맞춤형 예약 컨시어지"
+      }
+    },
+    "intro": {
+      "title": "룸빵일번지와 함께 즐기는 하이엔드 나이트 라이프",
+      "subtitle": "트렌디한 라운지부터 하이엔드 클럽까지, 취향에 맞춘 업소를 전문가가 직접 추천해드립니다.",
+      "features": [
+        {
+          "title": "믿을 수 있는 검수",
+          "description": "모든 제휴 파트너는 2단계 현장 검증을 거쳐 등록되며, 예약 품질을 상시 모니터링합니다."
+        },
+        {
+          "title": "실시간 상담",
+          "description": "카카오톡 · 전화 상담으로 원하는 시간과 인원에 맞춘 맞춤 코스를 제안합니다."
+        },
+        {
+          "title": "다양한 혜택",
+          "description": "룸빵일번지 회원만을 위한 특별 할인과 전용 룸 업그레이드 혜택을 제공해드립니다."
+        }
+      ]
+    },
+    "areas": {
+      "title": "추천 역별 라운지 & 클럽",
+      "subtitle": "지역 → 구 → 업종 필터를 조합해 원하는 매장을 빠르게 찾아보세요.",
+      "cta": "제휴 문의하기"
+    },
+    "categories": {
+      "title": "업종별 빠른 찾기",
+      "subtitle": "필터에서 원하는 업종을 선택하면 해당 업소만 모아볼 수 있습니다."
+    },
+    "process": {
+      "title": "이용 방법",
+      "steps": [
+        {
+          "number": "01",
+          "title": "필터로 원하는 조건 선택",
+          "description": "지역과 업종을 지정하면 가장 잘 맞는 파트너 업소를 추천합니다."
+        },
+        {
+          "number": "02",
+          "title": "전담 컨시어지 연결",
+          "description": "상담 버튼으로 연결되는 전담 컨시어지가 일정과 혜택을 세심하게 안내합니다."
+        },
+        {
+          "number": "03",
+          "title": "예약 및 방문",
+          "description": "예약이 확정되면 전용 혜택과 함께 완벽한 밤을 즐길 수 있도록 안내합니다."
+        }
+      ]
+    },
+    "cta": {
+      "title": "제휴 파트너가 되어보세요",
+      "subtitle": "룸빵일번지 네트워크에 합류하여 더 많은 프리미엄 고객을 만나보세요.",
+      "button": "제휴 상담 바로 연결"
+    },
+    "footer": {
+      "title": "룸빵일번지",
+      "description": "강남 · 수도권 · 부산의 프리미엄 룸과 라운지를 연결하는 원스톱 컨시어지 플랫폼입니다.",
+      "contactTitle": "상담 안내",
+      "contact": {
+        "partner": "제휴 문의",
+        "hours": "운영 시간",
+        "kakao": "카카오톡"
+      },
+      "contactHours": "12:00 ~ 03:00",
+      "kakaoId": "@roombbang1st",
+      "quickLinksTitle": "바로가기",
+      "links": {
+        "areas": "추천 지역",
+        "categories": "업종별 찾기",
+        "process": "이용 방법"
+      },
+      "copyright": "© {year} 룸빵일번지. All rights reserved."
+    },
+    "shop": {
+      "back": "메인으로 돌아가기",
+      "call": "즉시 전화 상담",
+      "address": "주소",
+      "phone": "대표 전화",
+      "manager": "담당 매니저",
+      "managerContact": "전담 매니저가 예약, 혜택, 행사 문의를 실시간으로 응대해드립니다.",
+      "hours": "영업시간",
+      "pricing": {
+        "title": "요금 안내",
+        "base": "주대",
+        "tc": "TC",
+        "rt": "RT"
+      },
+      "contact": {
+        "title": "담당자 상담 채널",
+        "manager": "담당자",
+        "phone": "연락처",
+        "kakao": "카카오톡"
+      },
+      "highlights": "핵심 포인트",
+      "seo": {
+        "title": "SEO 키워드 프리셋",
+        "description": "현재 등록된 키워드는 검색 노출 향상을 위해 메타 태그로 자동 반영됩니다. 필요에 따라 아래 편집기를 활용해 키워드를 다듬고, 저장을 위해 운영팀에 전달하세요.",
+        "editorLabel": "키워드 작성",
+        "copy": "키워드 복사",
+        "copySuccess": "키워드를 복사했습니다. 운영팀에 전달해 반영해주세요.",
+        "copyError": "복사에 실패했습니다. 직접 복사해주세요."
+      },
+      "gallery": {
+        "prev": "이전 이미지",
+        "next": "다음 이미지",
+        "dotLabel": "{{index}}번 이미지 보기"
+      },
+      "viewDetails": "자세히 보기",
+      "galleryAltFallback": "분위기"
+    },
+    "notFound": {
+      "title": "페이지를 찾을 수 없습니다.",
+      "description": "요청하신 페이지가 존재하지 않습니다. 메인으로 돌아가 다시 확인해주세요.",
+      "back": "← 메인으로 돌아가기"
+    }
+  },
+  "en": {
+    "languageCode": "en",
+    "languageName": "English",
+    "meta": {
+      "siteName": "Roombbang First",
+      "defaultTitle": "Roombbang First",
+      "indexTitle": "Roombbang First – Premium Nightlife Concierge",
+      "description": "Discover vetted premium rooms and lounges across Seoul, the capital region, and Busan curated by our concierge team.",
+      "shopTitleSuffix": " – Roombbang First"
+    },
+    "header": {
+      "tagline": "Premium room & lounge concierge platform",
+      "affiliate": "Partnership Inquiry",
+      "support": "Support 010-0000-0000",
+      "nav": {
+        "areas": "Featured Areas",
+        "categories": "Browse by Category",
+        "process": "How It Works",
+        "consult": "Partner Program"
+      },
+      "browseCta": "Explore Now",
+      "consultCta": "Quick Consultation",
+      "languageLabel": "Language"
+    },
+    "hero": {
+      "badge": "Seoul · Capital Area · Busan premium curation",
+      "headline": "From Gangnam to Haeundae, discover the hottest nightlife picks",
+      "description": "Use the region → district → category filters to instantly find a venue that matches your mood. Every partner is vetted in person by the Roombbang First concierge team.",
+      "filters": {
+        "region": "Region",
+        "district": "District",
+        "category": "Category",
+        "all": "All",
+        "action": "Search"
+      },
+      "highlights": [
+        "Live reservation concierge",
+        "Dedicated specialist assigned",
+        "VIP-tailored course suggestions"
+      ],
+      "stats": {
+        "shops": "Partner premium venues",
+        "response": "Rapid support 24/7",
+        "concierge": "1:1 tailored concierge"
+      }
+    },
+    "intro": {
+      "title": "Enjoy high-end nightlife with Roombbang First",
+      "subtitle": "From trendy lounges to high-end clubs, our specialists recommend venues that match your taste.",
+      "features": [
+        {
+          "title": "Trusted verification",
+          "description": "All partners undergo a two-step on-site inspection and continuous quality monitoring."
+        },
+        {
+          "title": "Real-time support",
+          "description": "Consult via KakaoTalk or phone for tailor-made courses that fit your schedule and group size."
+        },
+        {
+          "title": "Exclusive perks",
+          "description": "Enjoy member-only discounts and complimentary room upgrades reserved for Roombbang First clients."
+        }
+      ]
+    },
+    "areas": {
+      "title": "Featured lounges & clubs by station",
+      "subtitle": "Combine the filters to quickly surface venues that meet your criteria.",
+      "cta": "Contact Partnerships"
+    },
+    "categories": {
+      "title": "Browse by category",
+      "subtitle": "Select a category in the filter to focus on the venues you want."
+    },
+    "process": {
+      "title": "How it works",
+      "steps": [
+        {
+          "number": "01",
+          "title": "Pick your ideal filters",
+          "description": "Set your preferred region and category to receive matching partner venues."
+        },
+        {
+          "number": "02",
+          "title": "Get matched with a concierge",
+          "description": "A dedicated concierge guides you through schedules and benefits the moment you tap consult."
+        },
+        {
+          "number": "03",
+          "title": "Reserve and arrive",
+          "description": "Once confirmed, enjoy a flawless night out with exclusive perks prepared for you."
+        }
+      ]
+    },
+    "cta": {
+      "title": "Become a partner venue",
+      "subtitle": "Join the Roombbang First network to meet more premium clientele.",
+      "button": "Call partnership concierge"
+    },
+    "footer": {
+      "title": "Roombbang First",
+      "description": "A one-stop concierge platform connecting premium rooms and lounges in Seoul, the capital region, and Busan.",
+      "contactTitle": "Contact",
+      "contact": {
+        "partner": "Partnership line",
+        "hours": "Service hours",
+        "kakao": "KakaoTalk"
+      },
+      "contactHours": "12:00 – 03:00",
+      "kakaoId": "@roombbang1st",
+      "quickLinksTitle": "Quick links",
+      "links": {
+        "areas": "Featured areas",
+        "categories": "Browse by category",
+        "process": "How it works"
+      },
+      "copyright": "© {year} Roombbang First. All rights reserved."
+    },
+    "shop": {
+      "back": "Back to home",
+      "call": "Call concierge",
+      "address": "Address",
+      "phone": "Main line",
+      "manager": "Concierge",
+      "managerContact": "Your dedicated manager answers reservations, perks, and event requests in real time.",
+      "hours": "Business hours",
+      "pricing": {
+        "title": "Pricing",
+        "base": "Table",
+        "tc": "TC",
+        "rt": "RT"
+      },
+      "contact": {
+        "title": "Concierge contact",
+        "manager": "Manager",
+        "phone": "Phone",
+        "kakao": "KakaoTalk"
+      },
+      "highlights": "Highlights",
+      "seo": {
+        "title": "SEO keyword preset",
+        "description": "Registered keywords are automatically reflected in meta tags to improve search visibility. Refine them below and share with the operations team to update.",
+        "editorLabel": "Write keywords",
+        "copy": "Copy keywords",
+        "copySuccess": "Keywords copied. Share them with the ops team for publishing.",
+        "copyError": "Copy failed. Please copy them manually."
+      },
+      "gallery": {
+        "prev": "Previous image",
+        "next": "Next image",
+        "dotLabel": "View image {{index}}"
+      },
+      "viewDetails": "View details",
+      "galleryAltFallback": "ambience"
+    },
+    "notFound": {
+      "title": "Page not found",
+      "description": "The page you requested could not be found. Please return to the homepage and try again.",
+      "back": "← Back to home"
+    }
+  },
+  "zh": {
+    "languageCode": "zh",
+    "languageName": "中文",
+    "meta": {
+      "siteName": "房房一番地",
+      "defaultTitle": "房房一番地",
+      "indexTitle": "房房一番地 – 精品夜生活管家",
+      "description": "由專業管家團隊親自挑選，帶您探索首爾、首都圈與釜山的頂級包廂與酒廊。",
+      "shopTitleSuffix": " – 房房一番地"
+    },
+    "header": {
+      "tagline": "精品包廂・酒廊專屬管家平台",
+      "affiliate": "合作洽詢",
+      "support": "客服 010-0000-0000",
+      "nav": {
+        "areas": "推薦地區",
+        "categories": "依類型搜尋",
+        "process": "服務流程",
+        "consult": "合作指南"
+      },
+      "browseCta": "立即瀏覽",
+      "consultCta": "快速諮詢",
+      "languageLabel": "語言"
+    },
+    "hero": {
+      "badge": "首爾・首都圈・釜山精品策展",
+      "headline": "從江南到海雲台，發現最熱門的夜生活場域",
+      "description": "運用「地區 → 行政區 → 類型」的進階篩選，即刻找到符合情境的空間。所有合作店家皆由房房一番地管家團隊親自審核。",
+      "filters": {
+        "region": "地區",
+        "district": "行政區",
+        "category": "類型",
+        "all": "全部",
+        "action": "搜尋"
+      },
+      "highlights": [
+        "即時預約諮詢",
+        "專屬管家服務",
+        "VIP 客製行程"
+      ],
+      "stats": {
+        "shops": "合作精品場館",
+        "response": "全年無休即時回覆",
+        "concierge": "一對一貼身管家"
+      }
+    },
+    "intro": {
+      "title": "與房房一番地共度高端夜生活",
+      "subtitle": "從時尚酒廊到頂級夜店，專家為您挑選最合適的場地。",
+      "features": [
+        {
+          "title": "嚴格審核",
+          "description": "所有合作夥伴皆經過兩階段實地評估，並持續監控服務品質。"
+        },
+        {
+          "title": "即時諮詢",
+          "description": "透過 KakaoTalk 或電話，依照人數與時間提供專屬行程建議。"
+        },
+        {
+          "title": "專屬禮遇",
+          "description": "享有房房一番地會員限定優惠與包廂升等福利。"
+        }
+      ]
+    },
+    "areas": {
+      "title": "推薦站點酒廊與夜店",
+      "subtitle": "靈活組合篩選條件，快速找到理想店家。",
+      "cta": "合作洽談"
+    },
+    "categories": {
+      "title": "依類型快速瀏覽",
+      "subtitle": "在篩選器中選擇想要的類型，即可專注檢視相關店家。"
+    },
+    "process": {
+      "title": "服務流程",
+      "steps": [
+        {
+          "number": "01",
+          "title": "選擇條件",
+          "description": "設定地區與類型，立即獲得最匹配的合作店家。"
+        },
+        {
+          "number": "02",
+          "title": "連線專屬管家",
+          "description": "點擊諮詢後，專屬管家將細心說明行程與優惠。"
+        },
+        {
+          "number": "03",
+          "title": "預約與到訪",
+          "description": "確認預約後，即享有專屬禮遇與完美夜晚。"
+        }
+      ]
+    },
+    "cta": {
+      "title": "成為合作夥伴",
+      "subtitle": "加入房房一番地網絡，接觸更多高端客群。",
+      "button": "立即聯絡合作管家"
+    },
+    "footer": {
+      "title": "房房一番地",
+      "description": "連結首爾、首都圈與釜山頂級包廂與酒廊的一站式管家平台。",
+      "contactTitle": "聯絡資訊",
+      "contact": {
+        "partner": "合作專線",
+        "hours": "服務時間",
+        "kakao": "KakaoTalk"
+      },
+      "contactHours": "12:00 – 03:00",
+      "kakaoId": "@roombbang1st",
+      "quickLinksTitle": "快速導覽",
+      "links": {
+        "areas": "推薦地區",
+        "categories": "依類型搜尋",
+        "process": "服務流程"
+      },
+      "copyright": "© {year} 房房一番地. All rights reserved."
+    },
+    "shop": {
+      "back": "返回首頁",
+      "call": "立即致電管家",
+      "address": "地址",
+      "phone": "聯絡電話",
+      "manager": "專屬管家",
+      "managerContact": "專屬管家即時為您處理預約、禮遇與活動諮詢。",
+      "hours": "營業時間",
+      "pricing": {
+        "title": "費用資訊",
+        "base": "包廂費",
+        "tc": "TC",
+        "rt": "RT"
+      },
+      "contact": {
+        "title": "管家聯絡方式",
+        "manager": "管家",
+        "phone": "電話",
+        "kakao": "KakaoTalk"
+      },
+      "highlights": "亮點特色",
+      "seo": {
+        "title": "SEO 關鍵字範本",
+        "description": "已登錄的關鍵字會自動寫入中繼資料以提升搜尋曝光。可在下方調整並回報營運團隊更新。",
+        "editorLabel": "撰寫關鍵字",
+        "copy": "複製關鍵字",
+        "copySuccess": "已複製關鍵字，請轉交營運團隊更新。",
+        "copyError": "複製失敗，請手動複製。"
+      },
+      "gallery": {
+        "prev": "上一張圖片",
+        "next": "下一張圖片",
+        "dotLabel": "檢視第 {{index}} 張圖片"
+      },
+      "viewDetails": "查看詳情",
+      "galleryAltFallback": "氛圍"
+    },
+    "notFound": {
+      "title": "找不到頁面",
+      "description": "您請求的頁面不存在，請返回首頁重新確認。",
+      "back": "← 返回首頁"
+    }
+  }
+}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: /sitemap.xml

--- a/public/scripts/filters.js
+++ b/public/scripts/filters.js
@@ -12,7 +12,8 @@
       return;
     }
 
-    const options = ['<option value="all">전체</option>'];
+    const allLabel = (districtFilter.dataset && districtFilter.dataset.allLabel) || 'All';
+    const options = [`<option value="all">${allLabel}</option>`];
 
     if (region !== 'all' && districtMap[region]) {
       districtMap[region].forEach((district) => {

--- a/public/scripts/language-switcher.js
+++ b/public/scripts/language-switcher.js
@@ -1,0 +1,12 @@
+(function () {
+  const switchers = document.querySelectorAll('[data-language-switcher]');
+
+  switchers.forEach((select) => {
+    select.addEventListener('change', (event) => {
+      const value = event.target.value;
+      if (value) {
+        window.location.href = value;
+      }
+    });
+  });
+})();

--- a/public/scripts/shop-detail.js
+++ b/public/scripts/shop-detail.js
@@ -6,8 +6,13 @@
     const prev = slider.querySelector('[data-slider-prev]');
     const next = slider.querySelector('[data-slider-next]');
     const dotsHost = slider.querySelector('[data-slider-dots]');
+    const dotLabelTemplate = slider.dataset.dotLabel || 'View image {{index}}';
     let index = 0;
     let timer;
+
+    function getDotLabel(dotIndex) {
+      return dotLabelTemplate.replace('{{index}}', dotIndex + 1);
+    }
 
     function updateTransform() {
       track.style.transform = `translateX(-${index * 100}%)`;
@@ -50,7 +55,7 @@
         const dot = document.createElement('button');
         dot.type = 'button';
         dot.className = 'detail-gallery__dot';
-        dot.setAttribute('aria-label', `${dotIndex + 1}번 이미지 보기`);
+        dot.setAttribute('aria-label', getDotLabel(dotIndex));
         dot.addEventListener('click', () => {
           goToSlide(dotIndex);
           stopAuto();
@@ -92,6 +97,8 @@
     const copyButton = seoEditor.querySelector('[data-action="copy"]');
     const status = seoEditor.querySelector('[data-status]');
     const metaKeywords = document.querySelector('meta[name="keywords"]');
+    const successMessage = seoEditor.dataset.successMessage || 'Copied keywords.';
+    const errorMessage = seoEditor.dataset.errorMessage || 'Copy failed. Please try again.';
     let statusTimer;
 
     if (!textarea) {
@@ -126,10 +133,10 @@
       copyButton.addEventListener('click', async () => {
         try {
           await navigator.clipboard.writeText(textarea.value);
-          setStatus('키워드를 복사했습니다. 운영팀에 전달해 반영해주세요.', true);
+          setStatus(successMessage, true);
         } catch (error) {
           console.warn('Clipboard copy failed:', error);
-          setStatus('복사에 실패했습니다. 직접 복사해주세요.', false);
+          setStatus(errorMessage, false);
         }
       });
     }

--- a/views/404.ejs
+++ b/views/404.ejs
@@ -1,9 +1,9 @@
-<%- include('partials/head', { title: '페이지를 찾을 수 없습니다 - Gangnam King' }) %>
+<%- include('partials/head', { title: pageTitle, description: metaDescription }) %>
   <section class="section section--center">
     <div class="container container--small">
-      <h1>페이지를 찾을 수 없습니다.</h1>
-      <p>요청하신 페이지가 존재하지 않습니다. 메인으로 돌아가 다시 확인해주세요.</p>
-      <a class="back-link" href="/">← 메인으로 돌아가기</a>
+      <h1><%= t.notFound && t.notFound.title ? t.notFound.title : 'Page not found' %></h1>
+      <p><%= t.notFound && t.notFound.description ? t.notFound.description : '' %></p>
+      <a class="back-link" href="/"><%= t.notFound && t.notFound.back ? t.notFound.back : '← Back to home' %></a>
     </div>
   </section>
 <%- include('partials/footer') %>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -1,61 +1,64 @@
-<%- include('partials/head', { title: '룸빵일번지 - 프리미엄 유흥 공간 가이드', seoKeywords }) %>
+<%- include('partials/head', { title: pageTitle, description: metaDescription, seoKeywords }) %>
   <section class="hero">
     <div class="hero__overlay"></div>
     <div class="container hero__container">
       <div class="hero__text">
-        <span class="badge">서울 · 수도권 · 부산 프리미엄 큐레이션</span>
-        <h1>강남부터 해운대까지, 룸빵일번지가 추천하는 야간 핫플</h1>
-        <p>
-          지역 → 구 → 업종 순으로 세분화된 필터를 활용해 원하는 무드의 공간을 바로 찾아보세요.
-          모든 파트너는 룸빵일번지 전문 매칭팀이 직접 검증한 곳만 소개합니다.
-        </p>
+        <span class="badge"><%= t.hero && t.hero.badge ? t.hero.badge : '' %></span>
+        <h1><%= t.hero && t.hero.headline ? t.hero.headline : '' %></h1>
+        <p><%= t.hero && t.hero.description ? t.hero.description : '' %></p>
         <div class="hero__search">
           <div class="hero__filters">
             <label class="input-group">
-              <span>지역</span>
+              <span><%= t.hero && t.hero.filters ? t.hero.filters.region : '' %></span>
               <select id="region-filter">
-                <option value="all">전체</option>
+                <option value="all"><%= t.hero && t.hero.filters ? t.hero.filters.all : 'All' %></option>
                 <% regions.forEach(function(region) { %>
                   <option value="<%= region %>"><%= region %></option>
                 <% }) %>
               </select>
             </label>
             <label class="input-group">
-              <span>구 / 군</span>
-              <select id="district-filter" disabled>
-                <option value="all">전체</option>
+              <span><%= t.hero && t.hero.filters ? t.hero.filters.district : '' %></span>
+              <select
+                id="district-filter"
+                data-all-label="<%= t.hero && t.hero.filters ? t.hero.filters.all : 'All' %>"
+                disabled
+              >
+                <option value="all"><%= t.hero && t.hero.filters ? t.hero.filters.all : 'All' %></option>
               </select>
             </label>
             <label class="input-group">
-              <span>업종</span>
+              <span><%= t.hero && t.hero.filters ? t.hero.filters.category : '' %></span>
               <select id="category-filter">
-                <option value="all">전체</option>
+                <option value="all"><%= t.hero && t.hero.filters ? t.hero.filters.all : 'All' %></option>
                 <% categories.forEach(function(category) { %>
                   <option value="<%= category %>"><%= category %></option>
                 <% }) %>
               </select>
             </label>
           </div>
-          <button class="btn btn--primary btn--large" id="search-button" type="button">검색하기</button>
+          <button class="btn btn--primary btn--large" id="search-button" type="button">
+            <%= t.hero && t.hero.filters ? t.hero.filters.action : '' %>
+          </button>
         </div>
         <ul class="hero__highlights">
-          <li>실시간 예약 문의 연계</li>
-          <li>전담 컨시어지 배정</li>
-          <li>VIP 맞춤 코스 추천</li>
+          <% (t.hero && Array.isArray(t.hero.highlights) ? t.hero.highlights : []).forEach(function(item) { %>
+            <li><%= item %></li>
+          <% }) %>
         </ul>
       </div>
       <div class="hero__stats">
         <div class="stat-card">
           <span class="stat-card__number"><%= shops.length %>+</span>
-          <span class="stat-card__label">제휴된 프리미엄 매장</span>
+          <span class="stat-card__label"><%= t.hero && t.hero.stats ? t.hero.stats.shops : '' %></span>
         </div>
         <div class="stat-card">
           <span class="stat-card__number">24h</span>
-          <span class="stat-card__label">365일 빠른 응대</span>
+          <span class="stat-card__label"><%= t.hero && t.hero.stats ? t.hero.stats.response : '' %></span>
         </div>
         <div class="stat-card">
           <span class="stat-card__number">1:1</span>
-          <span class="stat-card__label">맞춤형 예약 컨시어지</span>
+          <span class="stat-card__label"><%= t.hero && t.hero.stats ? t.hero.stats.concierge : '' %></span>
         </div>
       </div>
     </div>
@@ -64,24 +67,16 @@
   <section class="section section--intro">
     <div class="container section__container">
       <div>
-        <h2 class="section__title">룸빵일번지와 함께 즐기는 하이엔드 나이트 라이프</h2>
-        <p class="section__subtitle">
-          트렌디한 라운지부터 하이엔드 클럽까지, 취향에 맞춘 업소를 전문가가 직접 추천해드립니다.
-        </p>
+        <h2 class="section__title"><%= t.intro && t.intro.title ? t.intro.title : '' %></h2>
+        <p class="section__subtitle"><%= t.intro && t.intro.subtitle ? t.intro.subtitle : '' %></p>
       </div>
       <div class="feature-grid">
-        <div class="feature-card">
-          <h3>믿을 수 있는 검수</h3>
-          <p>모든 제휴 파트너는 2단계 현장 검증을 거쳐 등록되며, 예약 품질을 상시 모니터링합니다.</p>
-        </div>
-        <div class="feature-card">
-          <h3>실시간 상담</h3>
-          <p>카카오톡 · 전화 상담으로 원하는 시간과 인원에 맞춘 맞춤 코스를 제안합니다.</p>
-        </div>
-        <div class="feature-card">
-          <h3>다양한 혜택</h3>
-          <p>룸빵일번지 회원만을 위한 특별 할인과 전용 룸 업그레이드 혜택을 제공해드립니다.</p>
-        </div>
+        <% (t.intro && Array.isArray(t.intro.features) ? t.intro.features : []).forEach(function(feature) { %>
+          <div class="feature-card">
+            <h3><%= feature.title %></h3>
+            <p><%= feature.description %></p>
+          </div>
+        <% }) %>
       </div>
     </div>
   </section>
@@ -90,10 +85,10 @@
     <div class="container">
       <div class="section__header">
         <div>
-          <h2 class="section__title">추천 지역별 라운지 &amp; 클럽</h2>
-          <p class="section__subtitle">지역 → 구 → 업종 필터를 조합해 원하는 매장을 빠르게 찾아보세요.</p>
+          <h2 class="section__title"><%= t.areas && t.areas.title ? t.areas.title : '' %></h2>
+          <p class="section__subtitle"><%= t.areas && t.areas.subtitle ? t.areas.subtitle : '' %></p>
         </div>
-        <a class="btn btn--ghost" href="#consult">제휴 문의하기</a>
+        <a class="btn btn--ghost" href="#consult"><%= t.areas && t.areas.cta ? t.areas.cta : '' %></a>
       </div>
       <div class="shop-grid" data-grid>
         <% shops.forEach(function(shop) { %>
@@ -110,8 +105,12 @@
               <span class="shop-card__meta"><%= shop.region %> · <%= shop.district %> · <%= shop.category %></span>
               <h3><%= shop.name %></h3>
               <p><%= shop.description %></p>
-              <p class="shop-card__contact">담당 <strong><%= shop.manager.name %></strong> · <a href="tel:<%= shop.manager.phone %>"><%= shop.manager.phone %></a></p>
-              <a class="shop-card__link" href="/shops/<%= shop.id %>">자세히 보기</a>
+              <p class="shop-card__contact">
+                <%= t.shop && t.shop.manager ? t.shop.manager + ': ' : '' %>
+                <strong><%= shop.manager.name %></strong>
+                · <a href="tel:<%= shop.manager.phone %>"><%= shop.manager.phone %></a>
+              </p>
+              <a class="shop-card__link" href="/shops/<%= shop.id %>"><%= t.shop && t.shop.viewDetails ? t.shop.viewDetails : '' %></a>
             </div>
           </article>
         <% }) %>
@@ -121,8 +120,8 @@
 
   <section class="section section--muted" id="categories">
     <div class="container">
-      <h2 class="section__title">업종별 빠른 찾기</h2>
-      <p class="section__subtitle">필터에서 원하는 업종을 선택하면 해당 업소만 모아볼 수 있습니다.</p>
+      <h2 class="section__title"><%= t.categories && t.categories.title ? t.categories.title : '' %></h2>
+      <p class="section__subtitle"><%= t.categories && t.categories.subtitle ? t.categories.subtitle : '' %></p>
       <div class="category-chips">
         <% categories.forEach(function(category) { %>
           <span class="category-chip"><%= category %></span>
@@ -133,23 +132,15 @@
 
   <section class="section" id="process">
     <div class="container">
-      <h2 class="section__title">이용 방법</h2>
+      <h2 class="section__title"><%= t.process && t.process.title ? t.process.title : '' %></h2>
       <div class="step-grid">
-        <div class="step-card">
-          <span class="step-card__number">01</span>
-          <h3>필터로 원하는 조건 선택</h3>
-          <p>지역과 업종을 지정하면 가장 잘 맞는 파트너 업소를 추천합니다.</p>
-        </div>
-        <div class="step-card">
-          <span class="step-card__number">02</span>
-          <h3>전담 컨시어지 연결</h3>
-          <p>상담 버튼으로 연결되는 전담 컨시어지가 일정과 혜택을 세심하게 안내합니다.</p>
-        </div>
-        <div class="step-card">
-          <span class="step-card__number">03</span>
-          <h3>예약 및 방문</h3>
-          <p>예약이 확정되면 전용 혜택과 함께 완벽한 밤을 즐길 수 있도록 안내합니다.</p>
-        </div>
+        <% (t.process && Array.isArray(t.process.steps) ? t.process.steps : []).forEach(function(step) { %>
+          <div class="step-card">
+            <span class="step-card__number"><%= step.number %></span>
+            <h3><%= step.title %></h3>
+            <p><%= step.description %></p>
+          </div>
+        <% }) %>
       </div>
     </div>
   </section>
@@ -157,10 +148,10 @@
   <section class="section section--cta">
     <div class="container section--cta__content">
       <div>
-        <h2 class="section__title">제휴 파트너가 되어보세요</h2>
-        <p class="section__subtitle">룸빵일번지 네트워크에 합류하여 더 많은 프리미엄 고객을 만나보세요.</p>
+        <h2 class="section__title"><%= t.cta && t.cta.title ? t.cta.title : '' %></h2>
+        <p class="section__subtitle"><%= t.cta && t.cta.subtitle ? t.cta.subtitle : '' %></p>
       </div>
-      <a class="btn btn--primary btn--large" href="tel:01000000000">제휴 상담 바로 연결</a>
+      <a class="btn btn--primary btn--large" href="tel:01000000000"><%= t.cta && t.cta.button ? t.cta.button : '' %></a>
     </div>
   </section>
 

--- a/views/partials/footer.ejs
+++ b/views/partials/footer.ejs
@@ -2,30 +2,44 @@
     <footer class="site-footer" id="consult">
       <div class="container site-footer__content">
         <div>
-          <h3>룸빵일번지</h3>
-          <p>강남 · 수도권 · 부산의 프리미엄 룸과 라운지를 연결하는 원스톱 컨시어지 플랫폼입니다.</p>
+          <h3><%= (t.footer && t.footer.title) || (t.meta && t.meta.siteName) || '룸빵일번지' %></h3>
+          <p><%= (t.footer && t.footer.description) || '' %></p>
         </div>
         <div>
-          <h4>상담 안내</h4>
+          <h4><%= t.footer && t.footer.contactTitle ? t.footer.contactTitle : '' %></h4>
           <ul>
-            <li>제휴 문의: <a href="tel:01000000000">010-0000-0000</a></li>
-            <li>운영 시간: 12:00 ~ 03:00</li>
-            <li>카카오톡: @roombbang1st</li>
+            <li>
+              <%= t.footer && t.footer.contact ? t.footer.contact.partner : '' %>:
+              <a href="tel:01000000000">010-0000-0000</a>
+            </li>
+            <li>
+              <%= t.footer && t.footer.contact ? t.footer.contact.hours : '' %>:
+              <span><%= t.footer && t.footer.contactHours ? t.footer.contactHours : '' %></span>
+            </li>
+            <li>
+              <%= t.footer && t.footer.contact ? t.footer.contact.kakao : '' %>:
+              <span><%= t.footer && t.footer.kakaoId ? t.footer.kakaoId : '' %></span>
+            </li>
           </ul>
         </div>
         <div>
-          <h4>바로가기</h4>
+          <h4><%= t.footer && t.footer.quickLinksTitle ? t.footer.quickLinksTitle : '' %></h4>
           <ul>
-            <li><a href="#areas">추천 지역</a></li>
-            <li><a href="#categories">업종별 찾기</a></li>
-            <li><a href="#process">이용 방법</a></li>
+            <li><a href="#areas"><%= t.footer && t.footer.links ? t.footer.links.areas : '' %></a></li>
+            <li><a href="#categories"><%= t.footer && t.footer.links ? t.footer.links.categories : '' %></a></li>
+            <li><a href="#process"><%= t.footer && t.footer.links ? t.footer.links.process : '' %></a></li>
           </ul>
         </div>
       </div>
       <div class="site-footer__bottom">
-        <p>© <%= new Date().getFullYear() %> 룸빵일번지. All rights reserved.</p>
+        <p>
+          <%= t.footer && t.footer.copyright
+            ? t.footer.copyright.replace('{year}', new Date().getFullYear())
+            : `© ${new Date().getFullYear()} 룸빵일번지. All rights reserved.` %>
+        </p>
       </div>
     </footer>
+    <script src="/scripts/language-switcher.js"></script>
     <% if (scripts) { %>
       <% scripts.forEach(function (script) { %>
         <script src="<%= script %>"></script>

--- a/views/partials/head.ejs
+++ b/views/partials/head.ejs
@@ -1,11 +1,35 @@
 <!DOCTYPE html>
-<html lang="ko">
+<html lang="<%= lang || 'ko' %>">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title><%= title %></title>
+    <title><%= title || (t.meta && t.meta.defaultTitle) || 'Gangnam King' %></title>
+    <meta
+      name="description"
+      content="<%= (typeof description === 'string' && description.length) ? description : ((t.meta && t.meta.description) || '') %>"
+    />
+    <meta name="robots" content="index, follow" />
+    <meta name="googlebot" content="index, follow" />
     <% if (seoKeywords && seoKeywords.length) { %>
       <meta name="keywords" content="<%= seoKeywords.join(', ') %>" />
+    <% } %>
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="<%= title || (t.meta && t.meta.defaultTitle) || 'Gangnam King' %>" />
+    <meta
+      property="og:description"
+      content="<%= (typeof description === 'string' && description.length) ? description : ((t.meta && t.meta.description) || '') %>"
+    />
+    <meta property="og:site_name" content="<%= (t.meta && t.meta.siteName) || 'Gangnam King' %>" />
+    <meta property="og:url" content="<%= canonicalUrl %>" />
+    <link rel="canonical" href="<%= canonicalUrl %>" />
+    <% if (languageOptions && languageOptions.length) { %>
+      <% languageOptions.forEach(function(option) { %>
+        <link rel="alternate" hreflang="<%= option.code %>" href="<%= option.absoluteUrl %>" />
+      <% }) %>
+      <% const defaultOption = languageOptions.find(function(option) { return option.code === defaultLanguage; }) || languageOptions[0]; %>
+      <% if (defaultOption) { %>
+        <link rel="alternate" hreflang="x-default" href="<%= defaultOption.absoluteUrl %>" />
+      <% } %>
     <% } %>
     <link rel="stylesheet" href="/styles/main.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -19,24 +43,36 @@
     <header class="site-header">
       <div class="site-header__topbar">
         <div class="container">
-          <span>프리미엄 룸 · 라운지 컨시어지 플랫폼</span>
+          <span><%= t.header && t.header.tagline ? t.header.tagline : '' %></span>
           <div class="topbar__links">
-            <a href="#consult">제휴 문의</a>
-            <a href="tel:01000000000">고객센터 010-0000-0000</a>
+            <a href="#consult"><%= t.header && t.header.affiliate ? t.header.affiliate : '' %></a>
+            <a href="tel:01000000000"><%= t.header && t.header.support ? t.header.support : '' %></a>
           </div>
         </div>
       </div>
       <div class="container site-header__main">
-        <a class="branding" href="/">룸빵일번지</a>
+        <a class="branding" href="/"><%= (t.meta && t.meta.siteName) || '룸빵일번지' %></a>
         <nav class="nav">
-          <a href="#areas">추천 지역</a>
-          <a href="#categories">업종별 찾기</a>
-          <a href="#process">진행 절차</a>
-          <a href="#consult">제휴 안내</a>
+          <a href="#areas"><%= t.header && t.header.nav ? t.header.nav.areas : '' %></a>
+          <a href="#categories"><%= t.header && t.header.nav ? t.header.nav.categories : '' %></a>
+          <a href="#process"><%= t.header && t.header.nav ? t.header.nav.process : '' %></a>
+          <a href="#consult"><%= t.header && t.header.nav ? t.header.nav.consult : '' %></a>
         </nav>
         <div class="header-actions">
-          <a class="btn btn--ghost" href="#areas">바로 둘러보기</a>
-          <a class="btn btn--primary" href="#consult">빠른 상담</a>
+          <div class="language-switcher">
+            <select
+              aria-label="<%= t.header && t.header.languageLabel ? t.header.languageLabel : 'Language' %>"
+              data-language-switcher
+            >
+              <% (languageOptions || []).forEach(function(option) { %>
+                <option value="<%= option.url %>" <%= option.isCurrent ? 'selected' : '' %>>
+                  <%= option.label %>
+                </option>
+              <% }) %>
+            </select>
+          </div>
+          <a class="btn btn--ghost" href="#areas"><%= t.header && t.header.browseCta ? t.header.browseCta : '' %></a>
+          <a class="btn btn--primary" href="#consult"><%= t.header && t.header.consultCta ? t.header.consultCta : '' %></a>
         </div>
       </div>
     </header>

--- a/views/shop.ejs
+++ b/views/shop.ejs
@@ -1,12 +1,23 @@
-<% const galleryImages = Array.isArray(shop.gallery) && shop.gallery.length ? shop.gallery : [{ src: shop.image, alt: shop.name + ' 분위기' }]; %>
-<%- include('partials/head', { title: shop.name + ' - 룸빵일번지', seoKeywords }) %>
+<%
+  const fallbackAltSuffix = (t.shop && t.shop.galleryAltFallback) || '분위기';
+  const galleryImages = Array.isArray(shop.gallery) && shop.gallery.length
+    ? shop.gallery
+    : [{ src: shop.image, alt: `${shop.name} ${fallbackAltSuffix}` }];
+%>
+<%- include('partials/head', { title: pageTitle, description: metaDescription, seoKeywords }) %>
   <section class="detail-hero">
     <div class="container detail-hero__grid">
-      <div class="detail-gallery" data-slider>
+      <div
+        class="detail-gallery"
+        data-slider
+        data-dot-label="<%= t.shop && t.shop.gallery ? t.shop.gallery.dotLabel : 'View image {{index}}' %>"
+      >
         <div class="detail-gallery__track" data-slider-track>
           <% galleryImages.forEach(function(image) {
                const source = typeof image === 'string' ? image : image.src;
-               const altText = typeof image === 'string' ? shop.name + ' 분위기' : (image.alt || shop.name + ' 분위기');
+               const altText = typeof image === 'string'
+                 ? `${shop.name} ${fallbackAltSuffix}`
+                 : (image.alt || `${shop.name} ${fallbackAltSuffix}`);
           %>
             <figure class="detail-gallery__slide">
               <img src="<%= source %>" alt="<%= altText %>" />
@@ -17,13 +28,13 @@
           <button
             class="detail-gallery__control detail-gallery__control--prev"
             type="button"
-            aria-label="이전 이미지"
+            aria-label="<%= t.shop && t.shop.gallery ? t.shop.gallery.prev : 'Previous image' %>"
             data-slider-prev
           ></button>
           <button
             class="detail-gallery__control detail-gallery__control--next"
             type="button"
-            aria-label="다음 이미지"
+            aria-label="<%= t.shop && t.shop.gallery ? t.shop.gallery.next : 'Next image' %>"
             data-slider-next
           ></button>
           <div class="detail-gallery__dots" data-slider-dots></div>
@@ -35,33 +46,33 @@
         <p class="detail-hero__description"><%= shop.description %></p>
         <dl class="detail-hero__list">
           <div>
-            <dt>주소</dt>
+            <dt><%= t.shop && t.shop.address ? t.shop.address : 'Address' %></dt>
             <dd><%= shop.address %></dd>
           </div>
           <div>
-            <dt>대표 전화</dt>
+            <dt><%= t.shop && t.shop.phone ? t.shop.phone : 'Phone' %></dt>
             <dd><a href="tel:<%= shop.phone %>"><%= shop.phone %></a></dd>
           </div>
           <div>
-            <dt>담당 매니저</dt>
+            <dt><%= t.shop && t.shop.manager ? t.shop.manager : 'Manager' %></dt>
             <dd>
               <strong><%= shop.manager.name %></strong>
               <span class="detail-hero__manager-contact">
                 <a href="tel:<%= shop.manager.phone %>"><%= shop.manager.phone %></a>
                 <% if (shop.manager.kakao) { %>
-                  · 카카오톡 <%= shop.manager.kakao %>
+                  · <%= t.shop && t.shop.contact ? t.shop.contact.kakao : 'KakaoTalk' %> <%= shop.manager.kakao %>
                 <% } %>
               </span>
             </dd>
           </div>
           <div>
-            <dt>영업시간</dt>
+            <dt><%= t.shop && t.shop.hours ? t.shop.hours : 'Hours' %></dt>
             <dd><%= shop.hours %></dd>
           </div>
         </dl>
         <div class="detail-hero__actions">
-          <a class="btn btn--primary" href="tel:<%= shop.manager.phone %>">즉시 전화 상담</a>
-          <a class="back-link" href="/">메인으로 돌아가기</a>
+          <a class="btn btn--primary" href="tel:<%= shop.manager.phone %>"><%= t.shop && t.shop.call ? t.shop.call : 'Call now' %></a>
+          <a class="back-link" href="/"><%= t.shop && t.shop.back ? t.shop.back : 'Back to home' %></a>
         </div>
       </div>
     </div>
@@ -70,37 +81,40 @@
   <section class="section detail-section">
     <div class="container detail-section__grid">
       <div class="detail-card">
-        <h2>요금 안내</h2>
+        <h2><%= t.shop && t.shop.pricing ? t.shop.pricing.title : 'Pricing' %></h2>
         <div class="pricing-grid">
           <div class="pricing-card">
-            <h3>주대</h3>
+            <h3><%= t.shop && t.shop.pricing ? t.shop.pricing.base : 'Table' %></h3>
             <p><%= shop.pricing.base %></p>
           </div>
           <div class="pricing-card">
-            <h3>TC</h3>
+            <h3><%= t.shop && t.shop.pricing ? t.shop.pricing.tc : 'TC' %></h3>
             <p><%= shop.pricing.tc %></p>
           </div>
           <div class="pricing-card">
-            <h3>RT</h3>
+            <h3><%= t.shop && t.shop.pricing ? t.shop.pricing.rt : 'RT' %></h3>
             <p><%= shop.pricing.rt %></p>
           </div>
         </div>
       </div>
       <div class="detail-card">
-        <h2>담당자 상담 채널</h2>
+        <h2><%= t.shop && t.shop.contact ? t.shop.contact.title : 'Concierge contact' %></h2>
         <div class="contact-card">
-          <p>전담 매니저가 예약, 혜택, 행사 문의를 실시간으로 응대해드립니다.</p>
+          <p><%= t.shop && t.shop.managerContact ? t.shop.managerContact : '' %></p>
           <ul>
-            <li><strong>담당자</strong> <%= shop.manager.name %></li>
-            <li><strong>연락처</strong> <a href="tel:<%= shop.manager.phone %>"><%= shop.manager.phone %></a></li>
+            <li><strong><%= t.shop && t.shop.contact ? t.shop.contact.manager : 'Manager' %></strong> <%= shop.manager.name %></li>
+            <li>
+              <strong><%= t.shop && t.shop.contact ? t.shop.contact.phone : 'Phone' %></strong>
+              <a href="tel:<%= shop.manager.phone %>"><%= shop.manager.phone %></a>
+            </li>
             <% if (shop.manager.kakao) { %>
-              <li><strong>카카오톡</strong> <%= shop.manager.kakao %></li>
+              <li><strong><%= t.shop && t.shop.contact ? t.shop.contact.kakao : 'KakaoTalk' %></strong> <%= shop.manager.kakao %></li>
             <% } %>
           </ul>
         </div>
       </div>
       <div class="detail-card">
-        <h2>핵심 포인트</h2>
+        <h2><%= t.shop && t.shop.highlights ? t.shop.highlights : 'Highlights' %></h2>
         <ul class="detail-tags">
           <% shop.highlights.forEach(function(item) { %>
             <li><%= item %></li>
@@ -113,22 +127,24 @@
   <section class="section section--muted detail-seo">
     <div class="container detail-seo__grid">
       <div>
-        <h2>SEO 키워드 프리셋</h2>
-        <p class="detail-seo__description">
-          현재 등록된 키워드는 검색 노출 향상을 위해 메타 태그로 자동 반영됩니다. 필요에 따라 아래
-          편집기를 활용해 키워드를 다듬고, 저장을 위해 운영팀에 전달하세요.
-        </p>
+        <h2><%= t.shop && t.shop.seo ? t.shop.seo.title : 'SEO keywords' %></h2>
+        <p class="detail-seo__description"><%= t.shop && t.shop.seo ? t.shop.seo.description : '' %></p>
         <ul class="seo-chip-list">
           <% (seoKeywords || []).forEach(function(keyword) { %>
             <li><%= keyword %></li>
           <% }) %>
         </ul>
       </div>
-      <form class="seo-editor" data-seo-editor>
-        <label for="seo-keywords-input">키워드 작성</label>
+      <form
+        class="seo-editor"
+        data-seo-editor
+        data-success-message="<%= t.shop && t.shop.seo ? t.shop.seo.copySuccess : '' %>"
+        data-error-message="<%= t.shop && t.shop.seo ? t.shop.seo.copyError : '' %>"
+      >
+        <label for="seo-keywords-input"><%= t.shop && t.shop.seo ? t.shop.seo.editorLabel : 'Keywords' %></label>
         <textarea id="seo-keywords-input" rows="6"><%= (seoKeywords || []).join(', ') %></textarea>
         <div class="seo-editor__actions">
-          <button type="button" class="btn btn--ghost" data-action="copy">키워드 복사</button>
+          <button type="button" class="btn btn--ghost" data-action="copy"><%= t.shop && t.shop.seo ? t.shop.seo.copy : 'Copy' %></button>
           <span class="seo-editor__status" data-status role="status" aria-live="polite"></span>
         </div>
       </form>


### PR DESCRIPTION
## Summary
- add language detection middleware, localized shop data, and translation resources to render the site in Korean, English, and Chinese
- update layouts, detail pages, and scripts to display translated copy, localized UI labels, and language switching controls
- strengthen SEO with canonical and alternate tags, a dynamically generated sitemap, and a public robots.txt entry

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68e443377d9083259dae067138f043aa