### PR TITLE
Add branding assets and restyle header

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,11 @@ const express = require('express');
 const { URLSearchParams } = require('url');
 
 const SUPPORTED_LANGUAGES = ['ko', 'en', 'zh'];
+const LANGUAGE_FLAGS = {
+  ko: '🇰🇷',
+  en: '🇺🇸',
+  zh: '🇨🇳',
+};
 const DEFAULT_LANGUAGE = 'ko';
 
 const app = express();
@@ -143,6 +148,7 @@ app.use((req, res, next) => {
     return {
       code,
       label: translations[code]?.languageName || code.toUpperCase(),
+      flag: LANGUAGE_FLAGS[code] || '',
       url: relativeUrl,
       absoluteUrl,
       isCurrent: code === activeLang,

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -57,24 +57,6 @@ img {
   box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
 }
 
-.site-header__topbar {
-  border-bottom: 1px solid var(--color-border);
-  font-size: 0.85rem;
-  color: var(--color-muted);
-}
-
-.site-header__topbar .container {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0.6rem 1.5rem;
-}
-
-.topbar__links {
-  display: flex;
-  gap: 1.5rem;
-}
-
 .site-header__main {
   display: flex;
   align-items: center;
@@ -86,14 +68,22 @@ img {
 .branding {
   display: inline-flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.85rem;
   color: #fff;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
-.branding img {
-  height: 44px;
+.branding__logo {
+  height: 60px;
   width: auto;
-  filter: drop-shadow(0 6px 18px rgba(0, 0, 0, 0.35));
+  filter: drop-shadow(0 8px 24px rgba(0, 0, 0, 0.45));
+}
+
+.branding__text {
+  font-size: 1rem;
+  color: var(--color-text);
 }
 
 .sr-only {
@@ -118,6 +108,47 @@ img {
 .header-actions {
   display: flex;
   gap: 0.75rem;
+}
+
+.language-switcher {
+  position: relative;
+}
+
+.language-switcher__select {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  background: rgba(19, 11, 40, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  padding: 0.55rem 2.5rem 0.55rem 1rem;
+  color: var(--color-text);
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.language-switcher__select:focus {
+  outline: none;
+  border-color: rgba(255, 46, 139, 0.6);
+  box-shadow: 0 0 0 3px rgba(255, 46, 139, 0.2);
+}
+
+.language-switcher::after {
+  content: '\25BE';
+  position: absolute;
+  right: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--color-muted);
+  pointer-events: none;
+  font-size: 0.7rem;
+}
+
+.language-switcher__select option {
+  background: var(--color-surface);
+  color: var(--color-text);
 }
 
 .btn {

--- a/views/partials/head.ejs
+++ b/views/partials/head.ejs
@@ -31,6 +31,8 @@
         <link rel="alternate" hreflang="x-default" href="<%= defaultOption.absoluteUrl %>" />
       <% } %>
     <% } %>
+    <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon-roompang.png" />
+    <link rel="apple-touch-icon" href="/images/favicon-roompang.png" />
     <link rel="stylesheet" href="/styles/main.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -41,17 +43,15 @@
   </head>
   <body>
     <header class="site-header">
-      <div class="site-header__topbar">
-        <div class="container">
-          <span><%= t.header && t.header.tagline ? t.header.tagline : '' %></span>
-          <div class="topbar__links">
-            <a href="#consult"><%= t.header && t.header.affiliate ? t.header.affiliate : '' %></a>
-            <a href="tel:01000000000"><%= t.header && t.header.support ? t.header.support : '' %></a>
-          </div>
-        </div>
-      </div>
       <div class="container site-header__main">
-        <a class="branding" href="/"><%= (t.meta && t.meta.siteName) || '룸빵일번지' %></a>
+        <a class="branding" href="/">
+          <img
+            class="branding__logo"
+            src="/images/logo-roompang.png"
+            alt="<%= (t.meta && t.meta.siteName) || '룸빵일번지' %>"
+          />
+          <span class="branding__text"><%= (t.meta && t.meta.siteName) || '룸빵일번지' %></span>
+        </a>
         <nav class="nav">
           <a href="#areas"><%= t.header && t.header.nav ? t.header.nav.areas : '' %></a>
           <a href="#categories"><%= t.header && t.header.nav ? t.header.nav.categories : '' %></a>
@@ -61,12 +61,13 @@
         <div class="header-actions">
           <div class="language-switcher">
             <select
+              class="language-switcher__select"
               aria-label="<%= t.header && t.header.languageLabel ? t.header.languageLabel : 'Language' %>"
               data-language-switcher
             >
               <% (languageOptions || []).forEach(function(option) { %>
                 <option value="<%= option.url %>" <%= option.isCurrent ? 'selected' : '' %>>
-                  <%= option.label %>
+                  <%= option.flag ? option.flag + ' ' : '' %><%= option.label %>
                 </option>
               <% }) %>
             </select>


### PR DESCRIPTION
## Summary
- remove the unused top bar and swap the brand text for the roompang logo with larger sizing
- add favicon links and apply refreshed styling for the header branding and language selector
- decorate language options with regional flag emojis delivered from the server

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68e44a0d5e048325b1fed26ac4057724