### PR TITLE
Center header branding and refresh language switcher

### DIFF
--- a/public/images/flags/flag-ko.svg
+++ b/public/images/flags/flag-ko.svg
@@ -1,37 +1,33 @@
 <svg width="48" height="32" viewBox="0 0 48 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect width="48" height="32" rx="4" fill="#FFFFFF" />
-  <g fill="#0C0C0C">
-    <g transform="rotate(-45 10 8)">
-      <rect x="4" y="3" width="12" height="1.7" rx="0.85" />
-      <rect x="4" y="7" width="12" height="1.7" rx="0.85" />
-      <rect x="4" y="11" width="12" height="1.7" rx="0.85" />
+  <rect width="48" height="32" rx="4" fill="#FFFFFF"/>
+  <g fill="#111111">
+    <g transform="matrix(.94 -.34 .34 .94 2.4 2.6)">
+      <rect x="2" y="3" width="14" height="1.6" rx="0.8"/>
+      <rect x="2" y="7" width="14" height="1.6" rx="0.8"/>
+      <rect x="2" y="11" width="14" height="1.6" rx="0.8"/>
     </g>
-    <g transform="rotate(45 38 8)">
-      <rect x="32" y="3" width="12" height="1.7" rx="0.85" />
-      <rect x="32" y="11" width="12" height="1.7" rx="0.85" />
-      <rect x="32" y="7" width="5.2" height="1.7" rx="0.85" />
-      <rect x="38.8" y="7" width="5.2" height="1.7" rx="0.85" />
+    <g transform="matrix(.94 .34 -.34 .94 26.4 -2.2)">
+      <rect x="4" y="3" width="14" height="1.6" rx="0.8"/>
+      <rect x="4" y="11" width="14" height="1.6" rx="0.8"/>
+      <rect x="4" y="7" width="5.5" height="1.6" rx="0.8"/>
+      <rect x="12.5" y="7" width="5.5" height="1.6" rx="0.8"/>
     </g>
-    <g transform="rotate(45 38 24)">
-      <rect x="32" y="19" width="12" height="1.7" rx="0.85" />
-      <rect x="32" y="23" width="5.2" height="1.7" rx="0.85" />
-      <rect x="38.8" y="23" width="5.2" height="1.7" rx="0.85" />
-      <rect x="32" y="27" width="12" height="1.7" rx="0.85" />
+    <g transform="matrix(.94 .34 -.34 .94 26.4 9.4)">
+      <rect x="4" y="3" width="14" height="1.6" rx="0.8"/>
+      <rect x="4" y="7" width="5.5" height="1.6" rx="0.8"/>
+      <rect x="12.5" y="7" width="5.5" height="1.6" rx="0.8"/>
+      <rect x="4" y="11" width="14" height="1.6" rx="0.8"/>
     </g>
-    <g transform="rotate(-45 10 24)">
-      <rect x="4" y="19" width="5.2" height="1.7" rx="0.85" />
-      <rect x="10.8" y="19" width="5.2" height="1.7" rx="0.85" />
-      <rect x="4" y="23" width="12" height="1.7" rx="0.85" />
-      <rect x="4" y="27" width="5.2" height="1.7" rx="0.85" />
-      <rect x="10.8" y="27" width="5.2" height="1.7" rx="0.85" />
+    <g transform="matrix(.94 -.34 .34 .94 2.4 14.2)">
+      <rect x="2" y="3" width="5.5" height="1.6" rx="0.8"/>
+      <rect x="9" y="3" width="5.5" height="1.6" rx="0.8"/>
+      <rect x="2" y="7" width="14" height="1.6" rx="0.8"/>
+      <rect x="2" y="11" width="5.5" height="1.6" rx="0.8"/>
+      <rect x="9" y="11" width="5.5" height="1.6" rx="0.8"/>
     </g>
   </g>
-  <path
-    fill="#CD2E3A"
-    d="M24 8.2c-4.02 0-7.28 3.26-7.28 7.28 0 1.94.78 3.7 2.05 4.96a4.68 4.68 0 0 1 4.73-4.35 4.55 4.55 0 0 1 4.55 4.55c0 1.36-.6 2.6-1.58 3.45A7.28 7.28 0 1 0 24 8.2Z"
-  />
-  <path
-    fill="#0047A0"
-    d="M24 23.8c4.02 0 7.28-3.26 7.28-7.28 0-1.94-.78-3.7-2.05-4.96a4.68 4.68 0 0 1-4.73 4.35 4.55 4.55 0 0 1-4.55-4.55c0-1.36.6-2.6 1.58-3.45A7.28 7.28 0 1 0 24 23.8Z"
-  />
+  <path d="M24 8.1c-4.15 0-7.52 3.37-7.52 7.52 0 1.74.59 3.34 1.58 4.62a4.9 4.9 0 0 1 4.8-4.07c2.6 0 4.71 2.11 4.71 4.71 0 1.75-.93 3.29-2.33 4.15A7.52 7.52 0 1 0 24 8.1Z" fill="#CD2E3A"/>
+  <path d="M24 23.9c4.15 0 7.52-3.37 7.52-7.52 0-1.74-.59-3.34-1.58-4.62a4.9 4.9 0 0 1-4.8 4.07c-2.6 0-4.71-2.11-4.71-4.71 0-1.75.93-3.29 2.33-4.15A7.52 7.52 0 1 0 24 23.9Z" fill="#0047A0"/>
+  <path d="M27.46 15.79c1.56 0 2.83 1.26 2.83 2.82 0 1.57-1.27 2.84-2.83 2.84-1.55 0-2.82-1.27-2.82-2.84 0-1.56 1.27-2.82 2.82-2.82Z" fill="#CD2E3A"/>
+  <path d="M20.54 16.21c-1.56 0-2.83-1.26-2.83-2.82s1.27-2.83 2.83-2.83 2.82 1.27 2.82 2.83-1.27 2.82-2.82 2.82Z" fill="#0047A0"/>
 </svg>

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -58,12 +58,31 @@ img {
 }
 
 .site-header__main {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
   align-items: center;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  gap: 1.5rem;
+  gap: 1rem;
   padding: 1.25rem 1.5rem;
+}
+
+.site-header__spacer {
+  min-height: 1px;
+}
+
+@media (max-width: 640px) {
+  .site-header__main {
+    grid-template-columns: 1fr;
+    justify-items: center;
+    row-gap: 1rem;
+  }
+
+  .site-header__spacer {
+    display: none;
+  }
+
+  .language-select {
+    justify-self: center;
+  }
 }
 
 .branding {
@@ -74,7 +93,8 @@ img {
   font-weight: 700;
   letter-spacing: 0.01em;
   text-transform: none;
-  text-align: left;
+  text-align: center;
+  justify-self: center;
 }
 
 .branding__logo {
@@ -106,6 +126,11 @@ img {
   display: inline-flex;
   align-items: center;
   gap: 0.75rem;
+  justify-self: end;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(19, 11, 40, 0.85), rgba(66, 33, 99, 0.85));
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08), 0 10px 26px rgba(0, 0, 0, 0.35);
 }
 
 .language-select__flag {
@@ -125,30 +150,46 @@ img {
 
 .language-select__dropdown {
   appearance: none;
-  border: 1px solid rgba(255, 255, 255, 0.18);
+  border: 1px solid rgba(255, 255, 255, 0.22);
   border-radius: 999px;
-  background: linear-gradient(160deg, rgba(19, 11, 40, 0.92), rgba(40, 22, 72, 0.92));
-  color: #fff;
+  background:
+    linear-gradient(140deg, rgba(24, 16, 48, 0.95), rgba(54, 28, 92, 0.95)),
+    radial-gradient(circle at top, rgba(255, 46, 139, 0.45), transparent 62%);
+  color: #fdfcff;
   font-size: 0.95rem;
   font-weight: 600;
-  padding: 0.55rem 2.4rem 0.55rem 1rem;
+  padding: 0.6rem 2.6rem 0.6rem 1.1rem;
   cursor: pointer;
-  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.4);
-  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+  box-shadow: 0 16px 32px rgba(9, 3, 24, 0.6);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease,
+    background 0.2s ease;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath fill='%23F7F6FF' d='M1.41.59 6 5.17 10.59.59 12 2 6 8 0 2z'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
-  background-position: right 0.85rem center;
-  background-size: 0.75rem;
+  background-position: right 1.05rem center;
+  background-size: 0.8rem;
 }
 
 .language-select__dropdown:hover {
   transform: translateY(-1px);
+  border-color: rgba(255, 46, 139, 0.55);
+  box-shadow: 0 20px 34px rgba(13, 4, 34, 0.55);
 }
 
 .language-select__dropdown:focus-visible {
   outline: none;
-  border-color: rgba(255, 46, 139, 0.6);
-  box-shadow: 0 0 0 3px rgba(255, 46, 139, 0.18);
+  border-color: rgba(255, 150, 210, 0.75);
+  box-shadow: 0 0 0 3px rgba(255, 46, 139, 0.25);
+}
+
+.language-select__dropdown option {
+  color: #160c2d;
+  background-color: #f6f2ff;
+}
+
+.language-select__dropdown option:checked,
+.language-select__dropdown option:hover {
+  background-color: #ffe0f1;
+  color: #2f184f;
 }
 
 .btn {

--- a/views/partials/head.ejs
+++ b/views/partials/head.ejs
@@ -44,6 +44,7 @@
   <body>
     <header class="site-header">
       <div class="container site-header__main">
+        <div class="site-header__spacer" aria-hidden="true"></div>
         <a class="branding" href="/">
           <img
             class="branding__logo"


### PR DESCRIPTION
## Summary
- center the site logo in the header with spacer grid layout while keeping the language selector accessible
- restyle the language selector control for improved contrast and option legibility
- replace the Korean flag asset with an updated graphic matching the provided design

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e45a9fa5888325a846e9893b46ba3e