### PR TITLE
Refine Taegeukgi SVG and language selector layout

### DIFF
--- a/public/images/flags/flag-ko.svg
+++ b/public/images/flags/flag-ko.svg
@@ -1,37 +1,46 @@
-<svg width="48" height="32" viewBox="0 0 48 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect width="48" height="32" rx="4" fill="#FFFFFF" />
-  <g fill="#0C0C0C">
-    <g transform="rotate(-45 10 8)">
-      <rect x="4" y="3" width="12" height="1.7" rx="0.85" />
-      <rect x="4" y="7" width="12" height="1.7" rx="0.85" />
-      <rect x="4" y="11" width="12" height="1.7" rx="0.85" />
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 3 2" role="img" aria-label="Flag of South Korea">
+  <path fill="#fff" d="M0 0h3v2H0z" />
+  <g transform="translate(1.5 1)">
+    <circle r="0.6" fill="#cd2e3a" />
+    <path
+      d="M0.6 0A0.6 0.6 0 1 1-0.6 0C-0.6-0.331-0.331-0.6 0-0.6S0.6-0.331 0.6 0z"
+      fill="#0047a0"
+    />
+    <path
+      d="M0.6 0A0.6 0.6 0 0 0 0-0.6 0.3 0.3 0 0 0 0 0 0.3 0.3 0 0 1 0.6 0z"
+      fill="#cd2e3a"
+    />
+    <path
+      d="M-0.6 0A0.6 0.6 0 0 1 0 0.6 0.3 0.3 0 0 1 0 0 0.3 0.3 0 0 0-0.6 0z"
+      fill="#0047a0"
+    />
+  </g>
+  <g fill="#000">
+    <g transform="translate(0.5 0.5) rotate(-30)">
+      <rect width="0.9" height="0.12" rx="0.06" y="-0.06" x="-0.45" />
+      <rect width="0.9" height="0.12" rx="0.06" y="0.18" x="-0.45" />
+      <rect width="0.9" height="0.12" rx="0.06" y="0.42" x="-0.45" />
     </g>
-    <g transform="rotate(45 38 8)">
-      <rect x="32" y="3" width="12" height="1.7" rx="0.85" />
-      <rect x="32" y="11" width="12" height="1.7" rx="0.85" />
-      <rect x="32" y="7" width="5.2" height="1.7" rx="0.85" />
-      <rect x="38.8" y="7" width="5.2" height="1.7" rx="0.85" />
+    <g transform="translate(2.5 0.5) rotate(30)">
+      <rect width="0.9" height="0.12" rx="0.06" y="-0.06" x="-0.45" />
+      <rect width="0.9" height="0.12" rx="0.06" y="0.18" x="-0.45" />
+      <rect width="0.9" height="0.12" rx="0.06" y="0.42" x="-0.45" />
+      <rect width="0.36" height="0.12" rx="0.06" y="0.18" x="-0.18" fill="#fff" />
+      <rect width="0.36" height="0.12" rx="0.06" y="0.42" x="-0.18" fill="#fff" />
     </g>
-    <g transform="rotate(45 38 24)">
-      <rect x="32" y="19" width="12" height="1.7" rx="0.85" />
-      <rect x="32" y="23" width="5.2" height="1.7" rx="0.85" />
-      <rect x="38.8" y="23" width="5.2" height="1.7" rx="0.85" />
-      <rect x="32" y="27" width="12" height="1.7" rx="0.85" />
+    <g transform="translate(0.5 1.5) rotate(30)">
+      <rect width="0.9" height="0.12" rx="0.06" y="-0.06" x="-0.45" />
+      <rect width="0.36" height="0.12" rx="0.06" y="-0.06" x="-0.18" fill="#fff" />
+      <rect width="0.9" height="0.12" rx="0.06" y="0.18" x="-0.45" />
+      <rect width="0.36" height="0.12" rx="0.06" y="0.18" x="-0.18" fill="#fff" />
+      <rect width="0.9" height="0.12" rx="0.06" y="0.42" x="-0.45" />
     </g>
-    <g transform="rotate(-45 10 24)">
-      <rect x="4" y="19" width="5.2" height="1.7" rx="0.85" />
-      <rect x="10.8" y="19" width="5.2" height="1.7" rx="0.85" />
-      <rect x="4" y="23" width="12" height="1.7" rx="0.85" />
-      <rect x="4" y="27" width="5.2" height="1.7" rx="0.85" />
-      <rect x="10.8" y="27" width="5.2" height="1.7" rx="0.85" />
+    <g transform="translate(2.5 1.5) rotate(-30)">
+      <rect width="0.9" height="0.12" rx="0.06" y="-0.06" x="-0.45" />
+      <rect width="0.9" height="0.12" rx="0.06" y="0.18" x="-0.45" />
+      <rect width="0.9" height="0.12" rx="0.06" y="0.42" x="-0.45" />
+      <rect width="0.36" height="0.12" rx="0.06" y="-0.06" x="-0.18" fill="#fff" />
+      <rect width="0.36" height="0.12" rx="0.06" y="0.42" x="-0.18" fill="#fff" />
     </g>
   </g>
-  <path
-    fill="#CD2E3A"
-    d="M24 8.2c-4.02 0-7.28 3.26-7.28 7.28 0 1.94.78 3.7 2.05 4.96a4.68 4.68 0 0 1 4.73-4.35 4.55 4.55 0 0 1 4.55 4.55c0 1.36-.6 2.6-1.58 3.45A7.28 7.28 0 1 0 24 8.2Z"
-  />
-  <path
-    fill="#0047A0"
-    d="M24 23.8c4.02 0 7.28-3.26 7.28-7.28 0-1.94-.78-3.7-2.05-4.96a4.68 4.68 0 0 1-4.73 4.35 4.55 4.55 0 0 1-4.55-4.55c0-1.36.6-2.6 1.58-3.45A7.28 7.28 0 1 0 24 23.8Z"
-  />
 </svg>

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -58,12 +58,37 @@ img {
 }
 
 .site-header__main {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
   align-items: center;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  gap: 1.5rem;
+  column-gap: 0;
   padding: 1.25rem 1.5rem;
+}
+
+.site-header__spacer {
+  min-height: 1px;
+}
+
+@media (max-width: 640px) {
+  .site-header__main {
+    grid-template-columns: 1fr;
+    justify-items: center;
+    row-gap: 1rem;
+  }
+
+  .site-header__spacer {
+    display: none;
+  }
+
+  .language-select {
+    justify-self: center;
+    margin-right: 0;
+    align-items: center;
+  }
+
+  .language-select__dropdown {
+    min-width: 100%;
+  }
 }
 
 .branding {
@@ -74,7 +99,8 @@ img {
   font-weight: 700;
   letter-spacing: 0.01em;
   text-transform: none;
-  text-align: left;
+  text-align: center;
+  justify-self: center;
 }
 
 .branding__logo {
@@ -103,52 +129,89 @@ img {
 
 .language-select {
   margin-left: auto;
+  margin-right: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.35rem;
+  justify-self: end;
+  padding: 0.6rem 0.75rem 0.7rem;
+  border-radius: 16px;
+  background: linear-gradient(150deg, rgba(26, 17, 52, 0.92), rgba(60, 33, 102, 0.92));
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12), 0 12px 26px rgba(0, 0, 0, 0.38);
+  max-width: 12rem;
+}
+
+.language-select__top {
   display: inline-flex;
   align-items: center;
-  gap: 0.75rem;
+  justify-content: center;
+  gap: 0.45rem;
+  align-self: center;
+  text-align: center;
+  width: 100%;
 }
 
 .language-select__flag {
-  width: 48px;
-  height: 32px;
-  border-radius: 0.6rem;
+  width: 42px;
+  height: 30px;
+  border-radius: 0.5rem;
   object-fit: cover;
-  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.45);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.45);
+  border: 1px solid rgba(255, 255, 255, 0.18);
 }
 
 .language-select__label {
   font-size: 0.75rem;
-  letter-spacing: 0.18em;
+  letter-spacing: 0.22em;
   text-transform: uppercase;
-  color: var(--color-muted);
+  color: #f2efff;
+  font-weight: 600;
 }
 
 .language-select__dropdown {
   appearance: none;
   border: 1px solid rgba(255, 255, 255, 0.18);
-  border-radius: 999px;
-  background: linear-gradient(160deg, rgba(19, 11, 40, 0.92), rgba(40, 22, 72, 0.92));
-  color: #fff;
-  font-size: 0.95rem;
+  border-radius: 12px;
+  background:
+    linear-gradient(150deg, rgba(26, 17, 52, 0.92), rgba(46, 24, 80, 0.92)),
+    radial-gradient(circle at top, rgba(255, 46, 139, 0.4), transparent 60%);
+  color: #fdfcff;
+  font-size: 0.9rem;
   font-weight: 600;
-  padding: 0.55rem 2.4rem 0.55rem 1rem;
+  padding: 0.55rem 2.3rem 0.55rem 1rem;
+  min-width: 10.5rem;
   cursor: pointer;
-  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.4);
-  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+  box-shadow: 0 16px 28px rgba(9, 3, 24, 0.5);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease,
+    background 0.2s ease;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath fill='%23F7F6FF' d='M1.41.59 6 5.17 10.59.59 12 2 6 8 0 2z'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
-  background-position: right 0.85rem center;
+  background-position: right 0.9rem center;
   background-size: 0.75rem;
 }
 
 .language-select__dropdown:hover {
   transform: translateY(-1px);
+  border-color: rgba(255, 46, 139, 0.55);
+  box-shadow: 0 20px 34px rgba(13, 4, 34, 0.55);
 }
 
 .language-select__dropdown:focus-visible {
   outline: none;
-  border-color: rgba(255, 46, 139, 0.6);
-  box-shadow: 0 0 0 3px rgba(255, 46, 139, 0.18);
+  border-color: rgba(255, 150, 210, 0.75);
+  box-shadow: 0 0 0 3px rgba(255, 46, 139, 0.25);
+}
+
+.language-select__dropdown option {
+  color: #160c2d;
+  background-color: #f6f2ff;
+}
+
+.language-select__dropdown option:checked,
+.language-select__dropdown option:hover {
+  background-color: #ffe0f1;
+  color: #2f184f;
 }
 
 .btn {

--- a/views/partials/head.ejs
+++ b/views/partials/head.ejs
@@ -44,6 +44,7 @@
   <body>
     <header class="site-header">
       <div class="container site-header__main">
+        <div class="site-header__spacer" aria-hidden="true"></div>
         <a class="branding" href="/">
           <img
             class="branding__logo"
@@ -56,14 +57,18 @@
         <% const languageSelectId = 'language-select'; %>
         <% if (currentLanguageOption) { %>
           <div class="language-select">
-            <% if (currentLanguageOption.flagSrc) { %>
-              <img
-                class="language-select__flag"
-                src="<%= currentLanguageOption.flagSrc %>"
-                alt="<%= currentLanguageOption.flagAlt || currentLanguageOption.label %>"
-              />
-            <% } %>
-            <label class="language-select__label" for="<%= languageSelectId %>">Language</label>
+            <div class="language-select__top">
+              <% if (currentLanguageOption.flagSrc) { %>
+                <img
+                  class="language-select__flag"
+                  src="<%= currentLanguageOption.flagSrc %>"
+                  alt="<%= currentLanguageOption.flagAlt || currentLanguageOption.label %>"
+                />
+              <% } %>
+              <label class="language-select__label" for="<%= languageSelectId %>">
+                Language
+              </label>
+            </div>
             <select
               class="language-select__dropdown"
               id="<%= languageSelectId %>"


### PR DESCRIPTION
## Summary
- replace the Korean flag asset with an updated Taegeukgi matching the provided reference
- center the language selector header stack and trim the control's dimensions for a tighter fit

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68e45a9fa5888325a846e9893b46ba3e