### PR TITLE
Improve mobile layout of homepage

### DIFF
--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -71,23 +71,59 @@ img {
 
 @media (max-width: 640px) {
   .site-header__main {
-    grid-template-columns: 1fr;
-    justify-items: center;
-    row-gap: 1rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    text-align: center;
   }
 
   .site-header__spacer {
     display: none;
   }
 
+  .branding {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .branding__logo {
+    height: 96px;
+  }
+
+  .branding__text {
+    font-size: 1.6rem;
+  }
+
   .language-select {
+    width: min(100%, 320px);
     justify-self: center;
     margin-right: 0;
-    align-items: center;
+    align-items: stretch;
+    text-align: left;
+    padding: 0.75rem 1rem;
+  }
+
+  .language-select__top {
+    justify-content: space-between;
+  }
+
+  .language-select__flag {
+    width: 36px;
+    height: 26px;
+  }
+
+  .language-select__label {
+    font-size: 0.7rem;
+    letter-spacing: 0.18em;
   }
 
   .language-select__dropdown {
-    min-width: 100%;
+    width: 100%;
+    min-width: 0;
+    font-size: 0.85rem;
+    margin-top: 0.5rem;
   }
 }
 
@@ -947,23 +983,15 @@ img {
 
 @media (max-width: 768px) {
   .site-header__main {
+    display: flex;
     flex-direction: column;
-    align-items: flex-start;
+    align-items: center;
     gap: 1.25rem;
-  }
-
-  .nav {
-    order: 3;
-    flex-wrap: wrap;
-    gap: 1rem;
-  }
-
-  .header-actions {
-    order: 2;
+    text-align: center;
   }
 
   .branding {
-    gap: 1rem;
+    gap: 0.9rem;
   }
 
   .branding__logo {
@@ -975,15 +1003,16 @@ img {
   }
 
   .language-select {
-    width: 100%;
-    justify-content: flex-start;
+    width: min(100%, 340px);
     flex-wrap: wrap;
-    gap: 0.5rem 1rem;
+    gap: 0.5rem;
+    align-items: stretch;
+    justify-content: center;
   }
 
   .language-select__dropdown {
     width: 100%;
-    max-width: 240px;
+    max-width: none;
   }
 
   .hero {
@@ -992,19 +1021,85 @@ img {
 }
 
 @media (max-width: 540px) {
+  .hero {
+    padding: 4rem 0 3rem;
+  }
+
+  .hero__search {
+    flex-direction: column;
+    gap: 0.75rem;
+    width: 100%;
+  }
+
   .hero__filters {
     width: 100%;
+    gap: 0.75rem;
   }
 
   .input-group {
     width: 100%;
   }
 
-  .hero__search {
+  .hero__search .btn {
+    width: 100%;
+  }
+
+  .section {
+    padding: 3.2rem 0;
+  }
+
+  .section__header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1.25rem;
+  }
+
+  .section__title {
+    font-size: 1.75rem;
+  }
+
+  .section__subtitle {
+    font-size: 0.95rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .container {
+    padding: 0 1.1rem;
+  }
+
+  .site-header__main {
+    padding: 1rem 1.1rem;
+  }
+
+  .language-select {
+    padding: 0.65rem 0.85rem;
+  }
+
+  .hero__text h1 {
+    font-size: clamp(1.8rem, 4vw + 1.2rem, 2.4rem);
+  }
+
+  .hero__text p {
+    font-size: 0.95rem;
+  }
+
+  .hero__highlights {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .shop-card {
+    border-radius: 18px;
+  }
+
+  .section--cta__content {
+    flex-direction: column;
     align-items: stretch;
   }
 
-  .hero__search .btn {
+  .section--cta__content .btn {
     width: 100%;
+    justify-content: center;
   }
 }


### PR DESCRIPTION
## Summary
- refine the sticky header and language switcher layout so they center and scale gracefully on phones
- stack hero filters and adjust section spacing/typography to avoid overflow on small screens
- tweak container padding and CTA/button layouts for better one-handed interaction on mobile

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68e4c0184520832595b0def8481f7b26