### PR TITLE
Refine responsive header and language selector sizing

### DIFF
--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -61,35 +61,34 @@ img {
   display: grid;
   grid-template-columns: 1fr auto 1fr;
   align-items: center;
-  column-gap: 0;
-  padding: 1.25rem 1.5rem;
+  column-gap: clamp(1rem, 3vw, 2.25rem);
+  padding: clamp(0.95rem, 1.5vw + 0.5rem, 1.35rem) clamp(1.25rem, 5vw, 2.25rem);
 }
 
 .site-header__spacer {
   min-height: 1px;
 }
 
-@media (max-width: 640px) {
+@media (max-width: 960px) {
   .site-header__main {
-    grid-template-columns: 1fr;
-    justify-items: center;
-    row-gap: 1rem;
+    column-gap: clamp(0.85rem, 2.5vw, 1.75rem);
+    padding: clamp(0.85rem, 1.25vw + 0.55rem, 1.15rem) clamp(1rem, 4vw, 1.75rem);
   }
 
-  .site-header__spacer {
-    display: none;
+  .branding__logo {
+    height: clamp(100px, 14vw, 114px);
+  }
+
+  .branding__text {
+    font-size: clamp(1.65rem, 3.2vw, 1.78rem);
   }
 
   .language-select {
-    justify-self: center;
-    margin-right: 0;
-    align-items: center;
-  }
-
-  .language-select__dropdown {
-    min-width: 100%;
+    max-width: 11rem;
+    padding: 0.55rem 0.7rem 0.65rem;
   }
 }
+
 
 .branding {
   display: inline-flex;
@@ -947,43 +946,60 @@ img {
 
 @media (max-width: 768px) {
   .site-header__main {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 1.25rem;
+    grid-template-columns: auto 1fr auto;
+    column-gap: clamp(0.65rem, 3vw, 1rem);
+    padding: clamp(0.75rem, 1.2vw + 0.5rem, 1rem) clamp(0.9rem, 4vw, 1.4rem);
   }
 
-  .nav {
-    order: 3;
-    flex-wrap: wrap;
-    gap: 1rem;
-  }
-
-  .header-actions {
-    order: 2;
+  .site-header__spacer {
+    width: clamp(2rem, 10vw, 3.75rem);
   }
 
   .branding {
-    gap: 1rem;
+    gap: clamp(0.6rem, 2.5vw, 0.9rem);
   }
 
   .branding__logo {
-    height: 108px;
+    height: clamp(88px, 17vw, 104px);
   }
 
   .branding__text {
-    font-size: 1.65rem;
+    font-size: clamp(1.4rem, 4vw, 1.55rem);
   }
 
   .language-select {
-    width: 100%;
-    justify-content: flex-start;
-    flex-wrap: wrap;
-    gap: 0.5rem 1rem;
+    flex-direction: row;
+    align-items: center;
+    justify-content: flex-end;
+    flex-wrap: nowrap;
+    gap: 0.4rem;
+    max-width: 9.75rem;
+    padding: 0.5rem 0.6rem;
+    margin: 0;
+  }
+
+  .language-select__top {
+    width: auto;
+    align-self: center;
+    gap: 0.3rem;
+  }
+
+  .language-select__flag {
+    width: 32px;
+    height: 24px;
+  }
+
+  .language-select__label {
+    font-size: 0.64rem;
+    letter-spacing: 0.18em;
   }
 
   .language-select__dropdown {
-    width: 100%;
-    max-width: 240px;
+    min-width: 0;
+    width: auto;
+    font-size: 0.8rem;
+    padding: 0.45rem 1.6rem 0.45rem 0.75rem;
+    background-position: right 0.8rem center;
   }
 
   .hero {
@@ -991,20 +1007,167 @@ img {
   }
 }
 
+@media (max-width: 640px) {
+  .site-header__main {
+    column-gap: clamp(0.55rem, 3vw, 0.85rem);
+    padding: clamp(0.65rem, 2vw + 0.35rem, 0.9rem) clamp(0.75rem, 5vw, 1.2rem);
+  }
+
+  .site-header__spacer {
+    width: clamp(1.5rem, 9vw, 2.75rem);
+  }
+
+  .branding {
+    gap: clamp(0.55rem, 2.5vw, 0.75rem);
+  }
+
+  .branding__logo {
+    height: clamp(72px, 18vw, 88px);
+  }
+
+  .branding__text {
+    font-size: clamp(1.25rem, 4.5vw, 1.4rem);
+  }
+
+  .language-select {
+    flex-direction: row;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0.35rem;
+    padding: 0.45rem 0.55rem;
+    border-radius: 12px;
+    max-width: 8.8rem;
+    margin-left: 0;
+    margin-right: 0;
+  }
+
+  .language-select__top {
+    width: auto;
+    align-self: center;
+    gap: 0.28rem;
+  }
+
+  .language-select__flag {
+    width: 28px;
+    height: 20px;
+  }
+
+  .language-select__label {
+    font-size: 0.58rem;
+    letter-spacing: 0.16em;
+  }
+
+  .language-select__dropdown {
+    min-width: 0;
+    width: auto;
+    font-size: 0.76rem;
+    padding: 0.42rem 1.35rem 0.42rem 0.7rem;
+    background-position: right 0.75rem center;
+  }
+}
+
 @media (max-width: 540px) {
+  .hero {
+    padding: 4rem 0 3rem;
+  }
+
+  .hero__search {
+    flex-direction: column;
+    gap: 0.75rem;
+    width: 100%;
+  }
+
   .hero__filters {
     width: 100%;
+    gap: 0.75rem;
   }
 
   .input-group {
     width: 100%;
   }
 
-  .hero__search {
+  .hero__search .btn {
+    width: 100%;
+  }
+
+  .section {
+    padding: 3.2rem 0;
+  }
+
+  .section__header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1.25rem;
+  }
+
+  .section__title {
+    font-size: 1.75rem;
+  }
+
+  .section__subtitle {
+    font-size: 0.95rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .container {
+    padding: 0 1.1rem;
+  }
+
+  .site-header__main {
+    column-gap: clamp(0.45rem, 3vw, 0.7rem);
+    padding: clamp(0.55rem, 2vw + 0.3rem, 0.75rem) clamp(0.65rem, 6vw, 1rem);
+  }
+
+  .site-header__spacer {
+    width: clamp(1.25rem, 8vw, 2.25rem);
+  }
+
+  .language-select {
+    max-width: 8rem;
+    padding: 0.4rem 0.5rem;
+  }
+
+  .language-select__flag {
+    width: 26px;
+    height: 18px;
+  }
+
+  .language-select__label {
+    font-size: 0.52rem;
+    letter-spacing: 0.14em;
+  }
+
+  .language-select__dropdown {
+    font-size: 0.72rem;
+    padding: 0.38rem 1.2rem 0.38rem 0.65rem;
+    background-position: right 0.6rem center;
+  }
+
+  .hero__text h1 {
+    font-size: clamp(1.8rem, 4vw + 1.2rem, 2.4rem);
+  }
+
+  .hero__text p {
+    font-size: 0.95rem;
+  }
+
+  .hero__highlights {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .shop-card {
+    border-radius: 18px;
+  }
+
+  .section--cta__content {
+    flex-direction: column;
     align-items: stretch;
   }
 
-  .hero__search .btn {
+  .section--cta__content .btn {
     width: 100%;
+    justify-content: center;
   }
 }


### PR DESCRIPTION
## Summary
- tighten the header grid spacing with fluid padding so the bar scales smoothly on smaller screens
- keep the branding centered while shrinking and right-aligning the language selector on tablets and phones
- fine-tune the mobile dropdown/flag typography for the language switcher so it stays legible without crowding the header

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68e4c0184520832595b0def8481f7b26