### PR TITLE
Relocate language selector and overhaul shop pricing view

### DIFF
--- a/data/translations.json
+++ b/data/translations.json
@@ -130,6 +130,32 @@
         "tc": "TC",
         "rt": "RT"
       },
+      "pricingTable": [
+        {
+          "label": "오후 9시 이전",
+          "meta": "주대 10 · TC 12 · RT 5",
+          "prices": [
+            { "label": "1인", "amount": "27만" },
+            { "label": "2인", "amount": "39만" },
+            { "label": "3인", "amount": "51만" },
+            { "label": "4인", "amount": "63만" }
+          ]
+        },
+        {
+          "label": "오후 9시 이후",
+          "meta": "주대 13 · TC 12 · RT 5",
+          "prices": [
+            { "label": "1인", "amount": "30만" },
+            { "label": "2인", "amount": "42만" },
+            { "label": "3인", "amount": "54만" },
+            { "label": "4인", "amount": "67만" }
+          ]
+        }
+      ],
+      "services": [
+        "강남권 픽업 서비스",
+        "발렛파킹 서비스"
+      ],
       "contact": {
         "title": "담당자 상담 채널",
         "manager": "담당자",
@@ -290,6 +316,32 @@
         "tc": "TC",
         "rt": "RT"
       },
+      "pricingTable": [
+        {
+          "label": "Before 9 PM",
+          "meta": "Cover 10 · TC 12 · RT 5",
+          "prices": [
+            { "label": "1 guest", "amount": "270K KRW" },
+            { "label": "2 guests", "amount": "390K KRW" },
+            { "label": "3 guests", "amount": "510K KRW" },
+            { "label": "4 guests", "amount": "630K KRW" }
+          ]
+        },
+        {
+          "label": "After 9 PM",
+          "meta": "Cover 13 · TC 12 · RT 5",
+          "prices": [
+            { "label": "1 guest", "amount": "300K KRW" },
+            { "label": "2 guests", "amount": "420K KRW" },
+            { "label": "3 guests", "amount": "540K KRW" },
+            { "label": "4 guests", "amount": "670K KRW" }
+          ]
+        }
+      ],
+      "services": [
+        "Gangnam pickup service",
+        "Valet parking service"
+      ],
       "contact": {
         "title": "Concierge contact",
         "manager": "Manager",
@@ -450,6 +502,32 @@
         "tc": "TC",
         "rt": "RT"
       },
+      "pricingTable": [
+        {
+          "label": "晚9點前",
+          "meta": "包廂費 10 · TC 12 · RT 5",
+          "prices": [
+            { "label": "1人", "amount": "27萬韓元" },
+            { "label": "2人", "amount": "39萬韓元" },
+            { "label": "3人", "amount": "51萬韓元" },
+            { "label": "4人", "amount": "63萬韓元" }
+          ]
+        },
+        {
+          "label": "晚9點後",
+          "meta": "包廂費 13 · TC 12 · RT 5",
+          "prices": [
+            { "label": "1人", "amount": "30萬韓元" },
+            { "label": "2人", "amount": "42萬韓元" },
+            { "label": "3人", "amount": "54萬韓元" },
+            { "label": "4人", "amount": "67萬韓元" }
+          ]
+        }
+      ],
+      "services": [
+        "江南地區接送服務",
+        "代客泊車服務"
+      ],
       "contact": {
         "title": "管家聯絡方式",
         "manager": "管家",
@@ -610,6 +688,32 @@
         "tc": "TC",
         "rt": "RT"
       },
+      "pricingTable": [
+        {
+          "label": "21時前",
+          "meta": "基本料金 10 ・ TC 12 ・ RT 5",
+          "prices": [
+            { "label": "1名", "amount": "27万ウォン" },
+            { "label": "2名", "amount": "39万ウォン" },
+            { "label": "3名", "amount": "51万ウォン" },
+            { "label": "4名", "amount": "63万ウォン" }
+          ]
+        },
+        {
+          "label": "21時以降",
+          "meta": "基本料金 13 ・ TC 12 ・ RT 5",
+          "prices": [
+            { "label": "1名", "amount": "30万ウォン" },
+            { "label": "2名", "amount": "42万ウォン" },
+            { "label": "3名", "amount": "54万ウォン" },
+            { "label": "4名", "amount": "67万ウォン" }
+          ]
+        }
+      ],
+      "services": [
+        "江南エリア送迎サービス",
+        "バレーパーキングサービス"
+      ],
       "contact": {
         "title": "担当者への連絡手段",
         "manager": "担当者",

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -58,38 +58,26 @@ img {
 }
 
 .site-header__main {
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
+  display: flex;
   align-items: center;
-  column-gap: 0;
-  padding: 1.25rem 1.5rem;
+  justify-content: center;
+  padding: clamp(0.95rem, 1.5vw + 0.5rem, 1.35rem) clamp(1.25rem, 5vw, 2.25rem);
 }
 
-.site-header__spacer {
-  min-height: 1px;
-}
-
-@media (max-width: 640px) {
+@media (max-width: 960px) {
   .site-header__main {
-    grid-template-columns: 1fr;
-    justify-items: center;
-    row-gap: 1rem;
+    padding: clamp(0.85rem, 1.25vw + 0.55rem, 1.1rem) clamp(1rem, 4vw, 1.75rem);
   }
 
-  .site-header__spacer {
-    display: none;
+  .branding__logo {
+    height: clamp(100px, 14vw, 114px);
   }
 
-  .language-select {
-    justify-self: center;
-    margin-right: 0;
-    align-items: center;
-  }
-
-  .language-select__dropdown {
-    min-width: 100%;
+  .branding__text {
+    font-size: clamp(1.65rem, 3.2vw, 1.78rem);
   }
 }
+
 
 .branding {
   display: inline-flex;
@@ -100,7 +88,6 @@ img {
   letter-spacing: 0.01em;
   text-transform: none;
   text-align: center;
-  justify-self: center;
 }
 
 .branding__logo {
@@ -128,41 +115,44 @@ img {
 }
 
 .language-select {
-  margin-left: auto;
-  margin-right: 0.5rem;
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
-  gap: 0.35rem;
-  justify-self: end;
-  padding: 0.6rem 0.75rem 0.7rem;
-  border-radius: 16px;
-  background: linear-gradient(150deg, rgba(26, 17, 52, 0.92), rgba(60, 33, 102, 0.92));
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12), 0 12px 26px rgba(0, 0, 0, 0.38);
-  max-width: 12rem;
+  align-items: flex-start;
+  gap: 0.6rem;
+  padding: 0.85rem 1rem;
+  border-radius: 18px;
+  background:
+    linear-gradient(150deg, rgba(26, 17, 52, 0.95), rgba(60, 33, 102, 0.95)),
+    radial-gradient(circle at top left, rgba(255, 46, 139, 0.25), transparent 65%);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.14), 0 20px 44px rgba(6, 0, 18, 0.6);
+  width: min(100%, 240px);
+  color: #fdfcff;
+}
+
+.language-select--floating {
+  position: fixed;
+  left: clamp(1rem, 4vw, 2.75rem);
+  bottom: clamp(1rem, 5vw, 3rem);
+  z-index: 140;
 }
 
 .language-select__top {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  gap: 0.45rem;
-  align-self: center;
-  text-align: center;
-  width: 100%;
+  gap: 0.5rem;
 }
 
 .language-select__flag {
-  width: 42px;
-  height: 30px;
-  border-radius: 0.5rem;
+  width: 40px;
+  height: 28px;
+  border-radius: 0.55rem;
   object-fit: cover;
-  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.45);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.45);
   border: 1px solid rgba(255, 255, 255, 0.18);
 }
 
 .language-select__label {
-  font-size: 0.75rem;
+  font-size: 0.74rem;
   letter-spacing: 0.22em;
   text-transform: uppercase;
   color: #f2efff;
@@ -172,17 +162,17 @@ img {
 .language-select__dropdown {
   appearance: none;
   border: 1px solid rgba(255, 255, 255, 0.18);
-  border-radius: 12px;
+  border-radius: 14px;
   background:
     linear-gradient(150deg, rgba(26, 17, 52, 0.92), rgba(46, 24, 80, 0.92)),
-    radial-gradient(circle at top, rgba(255, 46, 139, 0.4), transparent 60%);
+    radial-gradient(circle at top, rgba(255, 46, 139, 0.38), transparent 60%);
   color: #fdfcff;
   font-size: 0.9rem;
   font-weight: 600;
-  padding: 0.55rem 2.3rem 0.55rem 1rem;
-  min-width: 10.5rem;
+  padding: 0.55rem 2.4rem 0.55rem 1rem;
+  width: 100%;
   cursor: pointer;
-  box-shadow: 0 16px 28px rgba(9, 3, 24, 0.5);
+  box-shadow: 0 18px 32px rgba(9, 3, 24, 0.48);
   transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease,
     background 0.2s ease;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath fill='%23F7F6FF' d='M1.41.59 6 5.17 10.59.59 12 2 6 8 0 2z'/%3E%3C/svg%3E");
@@ -194,7 +184,7 @@ img {
 .language-select__dropdown:hover {
   transform: translateY(-1px);
   border-color: rgba(255, 46, 139, 0.55);
-  box-shadow: 0 20px 34px rgba(13, 4, 34, 0.55);
+  box-shadow: 0 24px 36px rgba(13, 4, 34, 0.55);
 }
 
 .language-select__dropdown:focus-visible {
@@ -615,9 +605,24 @@ img {
   margin: 0.75rem 0 1.25rem;
 }
 
-.detail-hero__description {
-  color: var(--color-muted);
+.detail-hero__services {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
   margin-bottom: 1.75rem;
+}
+
+.detail-hero__service {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(255, 46, 139, 0.18);
+  color: #ff9bd1;
+  font-weight: 600;
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
 }
 
 .detail-hero__list {
@@ -639,22 +644,12 @@ img {
   font-size: 1.05rem;
 }
 
-.detail-hero__manager-contact {
-  display: block;
-  margin-top: 0.35rem;
-  color: var(--color-muted);
-}
-
-.detail-hero__manager-contact a {
-  color: inherit;
-  font-weight: 600;
-}
-
 .detail-hero__actions {
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;
   align-items: center;
+  justify-content: flex-start;
 }
 
 .detail-hero__actions .back-link {
@@ -685,63 +680,69 @@ img {
   margin-bottom: 1.5rem;
 }
 
-.detail-tags {
+.detail-card--full {
+  grid-column: 1 / -1;
+}
+
+.rate-table {
+  display: grid;
+  gap: 1.75rem;
+}
+
+.rate-table__block {
+  background: rgba(5, 3, 16, 0.78);
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  padding: 1.75rem;
+  box-shadow: inset 0 0 0 1px rgba(255, 46, 139, 0.12);
+}
+
+.rate-table__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.rate-table__header h3 {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.rate-table__meta {
+  color: var(--color-muted);
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.rate-table__list {
   list-style: none;
   padding: 0;
   margin: 0;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
+  display: grid;
+  gap: 0.6rem;
 }
 
-.detail-tags li {
-  padding: 0.55rem 1.1rem;
-  border-radius: 999px;
-  background: rgba(255, 46, 139, 0.16);
-  color: #ffd4eb;
-  font-weight: 600;
-}
-.pricing-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1.5rem;
-}
-.pricing-card {
-  background: rgba(5, 3, 16, 0.8);
-  border-radius: 18px;
+.rate-table__list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.85rem 1rem;
+  border-radius: 14px;
+  background: rgba(7, 5, 18, 0.85);
   border: 1px solid rgba(255, 255, 255, 0.08);
-  padding: 1.75rem;
-  text-align: center;
-  box-shadow: inset 0 0 0 1px rgba(255, 46, 139, 0.12);
 }
-.pricing-card h3 {
-  margin-top: 0;
-  margin-bottom: 0.75rem;
-}
-.pricing-card p {
-  margin: 0;
+
+.rate-table__person {
   color: var(--color-muted);
   font-weight: 500;
 }
-.contact-card {
-  background: rgba(5, 3, 16, 0.78);
-  border-radius: 18px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  padding: 1.75rem;
-}
-.contact-card ul {
-  list-style: none;
-  padding: 0;
-  margin: 1.25rem 0 0;
-  display: grid;
-  gap: 0.75rem;
-}
-.contact-card li {
-  color: var(--color-muted);
-}
-.contact-card a {
-  color: inherit;
-  font-weight: 600;
+
+.rate-table__amount {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: #fff;
 }
 
 .detail-seo__grid {
@@ -947,43 +948,37 @@ img {
 
 @media (max-width: 768px) {
   .site-header__main {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 1.25rem;
-  }
-
-  .nav {
-    order: 3;
-    flex-wrap: wrap;
-    gap: 1rem;
-  }
-
-  .header-actions {
-    order: 2;
+    padding: clamp(0.7rem, 1.2vw + 0.45rem, 0.95rem) clamp(0.9rem, 4vw, 1.4rem);
   }
 
   .branding {
-    gap: 1rem;
+    gap: clamp(0.55rem, 2.5vw, 0.85rem);
   }
 
   .branding__logo {
-    height: 108px;
+    height: clamp(88px, 17vw, 104px);
   }
 
   .branding__text {
-    font-size: 1.65rem;
+    font-size: clamp(1.4rem, 4vw, 1.6rem);
   }
 
   .language-select {
-    width: 100%;
-    justify-content: flex-start;
-    flex-wrap: wrap;
-    gap: 0.5rem 1rem;
+    width: min(100%, 220px);
+    padding: 0.75rem 0.9rem;
+  }
+
+  .language-select__flag {
+    width: 34px;
+    height: 24px;
+  }
+
+  .language-select__label {
+    font-size: 0.68rem;
   }
 
   .language-select__dropdown {
-    width: 100%;
-    max-width: 240px;
+    font-size: 0.84rem;
   }
 
   .hero {
@@ -991,20 +986,157 @@ img {
   }
 }
 
+@media (max-width: 640px) {
+  .site-header__main {
+    padding: clamp(0.6rem, 1.8vw + 0.35rem, 0.85rem) clamp(0.75rem, 5vw, 1.2rem);
+  }
+
+  .branding__logo {
+    height: clamp(72px, 18vw, 88px);
+  }
+
+  .branding__text {
+    font-size: clamp(1.25rem, 4.5vw, 1.42rem);
+  }
+
+  .language-select--floating {
+    left: clamp(0.85rem, 6vw, 1.5rem);
+    bottom: clamp(0.85rem, 5vw, 1.75rem);
+    width: calc(100% - 2 * clamp(0.85rem, 6vw, 1.5rem));
+  }
+
+  .language-select {
+    gap: 0.45rem;
+    padding: 0.65rem 0.85rem;
+  }
+
+  .language-select__flag {
+    width: 32px;
+    height: 22px;
+  }
+
+  .language-select__label {
+    font-size: 0.62rem;
+    letter-spacing: 0.18em;
+  }
+
+  .language-select__dropdown {
+    font-size: 0.8rem;
+    padding-right: 2rem;
+  }
+}
+
 @media (max-width: 540px) {
+  .hero {
+    padding: 4rem 0 3rem;
+  }
+
+  .hero__search {
+    flex-direction: column;
+    gap: 0.75rem;
+    width: 100%;
+  }
+
   .hero__filters {
     width: 100%;
+    gap: 0.75rem;
   }
 
   .input-group {
     width: 100%;
   }
 
-  .hero__search {
+  .hero__search .btn {
+    width: 100%;
+  }
+
+  .section {
+    padding: 3.2rem 0;
+  }
+
+  .section__header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1.25rem;
+  }
+
+  .section__title {
+    font-size: 1.75rem;
+  }
+
+  .section__subtitle {
+    font-size: 0.95rem;
+  }
+
+  .rate-table__header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .rate-table__list li {
+    padding: 0.75rem 0.9rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .container {
+    padding: 0 1.1rem;
+  }
+
+  .site-header__main {
+    padding: clamp(0.5rem, 2vw + 0.3rem, 0.75rem) clamp(0.65rem, 6vw, 1rem);
+  }
+
+  .language-select {
+    gap: 0.4rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .language-select__flag {
+    width: 28px;
+    height: 20px;
+  }
+
+  .language-select__label {
+    font-size: 0.58rem;
+    letter-spacing: 0.16em;
+  }
+
+  .language-select__dropdown {
+    font-size: 0.76rem;
+    padding: 0.45rem 1.6rem 0.45rem 0.75rem;
+    background-position: right 0.7rem center;
+  }
+
+  .language-select__dropdown option {
+    font-size: 0.9rem;
+  }
+
+  .hero__text h1 {
+    font-size: clamp(1.8rem, 4vw + 1.2rem, 2.4rem);
+  }
+
+  .hero__text p {
+    font-size: 0.95rem;
+  }
+
+  .hero__highlights {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .shop-card {
+    border-radius: 18px;
+  }
+
+  .section--cta__content {
+    flex-direction: column;
     align-items: stretch;
   }
 
-  .hero__search .btn {
+  .section--cta__content .btn {
     width: 100%;
+    justify-content: center;
   }
 }

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -104,12 +104,6 @@
             <div class="shop-card__body">
               <span class="shop-card__meta"><%= shop.region %> · <%= shop.district %> · <%= shop.category %></span>
               <h3><%= shop.name %></h3>
-              <p><%= shop.description %></p>
-              <p class="shop-card__contact">
-                <%= t.shop && t.shop.manager ? t.shop.manager + ': ' : '' %>
-                <strong><%= shop.manager.name %></strong>
-                · <a href="tel:<%= shop.manager.phone %>"><%= shop.manager.phone %></a>
-              </p>
               <a class="shop-card__link" href="/shops/<%= shop.id %>"><%= t.shop && t.shop.viewDetails ? t.shop.viewDetails : '' %></a>
             </div>
           </article>

--- a/views/partials/head.ejs
+++ b/views/partials/head.ejs
@@ -44,7 +44,6 @@
   <body>
     <header class="site-header">
       <div class="container site-header__main">
-        <div class="site-header__spacer" aria-hidden="true"></div>
         <a class="branding" href="/">
           <img
             class="branding__logo"
@@ -53,35 +52,35 @@
           />
           <span class="branding__text">룸빵일번지</span>
         </a>
-        <% const currentLanguageOption = (languageOptions || []).find(function(option) { return option.isCurrent; }) || (languageOptions || [])[0]; %>
-        <% const languageSelectId = 'language-select'; %>
-        <% if (currentLanguageOption) { %>
-          <div class="language-select">
-            <div class="language-select__top">
-              <% if (currentLanguageOption.flagSrc) { %>
-                <img
-                  class="language-select__flag"
-                  src="<%= currentLanguageOption.flagSrc %>"
-                  alt="<%= currentLanguageOption.flagAlt || currentLanguageOption.label %>"
-                />
-              <% } %>
-              <label class="language-select__label" for="<%= languageSelectId %>">
-                Language
-              </label>
-            </div>
-            <select
-              class="language-select__dropdown"
-              id="<%= languageSelectId %>"
-              data-language-select
-            >
-              <% (languageOptions || []).forEach(function(option) { %>
-                <option value="<%= option.url %>" <%= option.isCurrent ? 'selected' : '' %>>
-                  <%= option.label %>
-                </option>
-              <% }) %>
-            </select>
-          </div>
-        <% } %>
       </div>
     </header>
+    <% const currentLanguageOption = (languageOptions || []).find(function(option) { return option.isCurrent; }) || (languageOptions || [])[0]; %>
+    <% const languageSelectId = 'language-select'; %>
+    <% if (currentLanguageOption) { %>
+      <div class="language-select language-select--floating">
+        <div class="language-select__top">
+          <% if (currentLanguageOption.flagSrc) { %>
+            <img
+              class="language-select__flag"
+              src="<%= currentLanguageOption.flagSrc %>"
+              alt="<%= currentLanguageOption.flagAlt || currentLanguageOption.label %>"
+            />
+          <% } %>
+          <label class="language-select__label" for="<%= languageSelectId %>">
+            <%= (t.header && t.header.languageLabel) || 'Language' %>
+          </label>
+        </div>
+        <select
+          class="language-select__dropdown"
+          id="<%= languageSelectId %>"
+          data-language-select
+        >
+          <% (languageOptions || []).forEach(function(option) { %>
+            <option value="<%= option.url %>" <%= option.isCurrent ? 'selected' : '' %>>
+              <%= option.label %>
+            </option>
+          <% }) %>
+        </select>
+      </div>
+    <% } %>
     <main class="site-main">

--- a/views/shop.ejs
+++ b/views/shop.ejs
@@ -43,27 +43,19 @@
       <div class="detail-hero__info">
         <p class="detail-hero__meta"><%= shop.region %> · <%= shop.district %> · <%= shop.category %></p>
         <h1><%= shop.name %></h1>
-        <p class="detail-hero__description"><%= shop.description %></p>
+        <% const defaultServices = ['강남권 픽업 서비스', '발렛파킹 서비스']; %>
+        <% const serviceBadges = Array.isArray(t.shop && t.shop.services) && (t.shop.services.length ? t.shop.services : defaultServices) || defaultServices; %>
+        <% if (serviceBadges.length) { %>
+          <div class="detail-hero__services">
+            <% serviceBadges.forEach(function(service) { %>
+              <span class="detail-hero__service"><%= service %></span>
+            <% }) %>
+          </div>
+        <% } %>
         <dl class="detail-hero__list">
           <div>
             <dt><%= t.shop && t.shop.address ? t.shop.address : 'Address' %></dt>
             <dd><%= shop.address %></dd>
-          </div>
-          <div>
-            <dt><%= t.shop && t.shop.phone ? t.shop.phone : 'Phone' %></dt>
-            <dd><a href="tel:<%= shop.phone %>"><%= shop.phone %></a></dd>
-          </div>
-          <div>
-            <dt><%= t.shop && t.shop.manager ? t.shop.manager : 'Manager' %></dt>
-            <dd>
-              <strong><%= shop.manager.name %></strong>
-              <span class="detail-hero__manager-contact">
-                <a href="tel:<%= shop.manager.phone %>"><%= shop.manager.phone %></a>
-                <% if (shop.manager.kakao) { %>
-                  · <%= t.shop && t.shop.contact ? t.shop.contact.kakao : 'KakaoTalk' %> <%= shop.manager.kakao %>
-                <% } %>
-              </span>
-            </dd>
           </div>
           <div>
             <dt><%= t.shop && t.shop.hours ? t.shop.hours : 'Hours' %></dt>
@@ -71,7 +63,6 @@
           </div>
         </dl>
         <div class="detail-hero__actions">
-          <a class="btn btn--primary" href="tel:<%= shop.manager.phone %>"><%= t.shop && t.shop.call ? t.shop.call : 'Call now' %></a>
           <a class="back-link" href="/"><%= t.shop && t.shop.back ? t.shop.back : 'Back to home' %></a>
         </div>
       </div>
@@ -80,46 +71,51 @@
 
   <section class="section detail-section">
     <div class="container detail-section__grid">
-      <div class="detail-card">
+      <% const defaultPricingTable = [
+           {
+             label: '오후 9시 이전',
+             meta: '주대 10 · TC 12 · RT 5',
+             prices: [
+               { label: '1인', amount: '27만' },
+               { label: '2인', amount: '39만' },
+               { label: '3인', amount: '51만' },
+               { label: '4인', amount: '63만' },
+             ],
+           },
+           {
+             label: '오후 9시 이후',
+             meta: '주대 13 · TC 12 · RT 5',
+             prices: [
+               { label: '1인', amount: '30만' },
+               { label: '2인', amount: '42만' },
+               { label: '3인', amount: '54만' },
+               { label: '4인', amount: '67만' },
+             ],
+           },
+         ]; %>
+      <% const pricingTable = Array.isArray(t.shop && t.shop.pricingTable) && (t.shop.pricingTable.length ? t.shop.pricingTable : defaultPricingTable) || defaultPricingTable; %>
+      <div class="detail-card detail-card--full">
         <h2><%= t.shop && t.shop.pricing ? t.shop.pricing.title : 'Pricing' %></h2>
-        <div class="pricing-grid">
-          <div class="pricing-card">
-            <h3><%= t.shop && t.shop.pricing ? t.shop.pricing.base : 'Table' %></h3>
-            <p><%= shop.pricing.base %></p>
-          </div>
-          <div class="pricing-card">
-            <h3><%= t.shop && t.shop.pricing ? t.shop.pricing.tc : 'TC' %></h3>
-            <p><%= shop.pricing.tc %></p>
-          </div>
-          <div class="pricing-card">
-            <h3><%= t.shop && t.shop.pricing ? t.shop.pricing.rt : 'RT' %></h3>
-            <p><%= shop.pricing.rt %></p>
-          </div>
-        </div>
-      </div>
-      <div class="detail-card">
-        <h2><%= t.shop && t.shop.contact ? t.shop.contact.title : 'Concierge contact' %></h2>
-        <div class="contact-card">
-          <p><%= t.shop && t.shop.managerContact ? t.shop.managerContact : '' %></p>
-          <ul>
-            <li><strong><%= t.shop && t.shop.contact ? t.shop.contact.manager : 'Manager' %></strong> <%= shop.manager.name %></li>
-            <li>
-              <strong><%= t.shop && t.shop.contact ? t.shop.contact.phone : 'Phone' %></strong>
-              <a href="tel:<%= shop.manager.phone %>"><%= shop.manager.phone %></a>
-            </li>
-            <% if (shop.manager.kakao) { %>
-              <li><strong><%= t.shop && t.shop.contact ? t.shop.contact.kakao : 'KakaoTalk' %></strong> <%= shop.manager.kakao %></li>
-            <% } %>
-          </ul>
-        </div>
-      </div>
-      <div class="detail-card">
-        <h2><%= t.shop && t.shop.highlights ? t.shop.highlights : 'Highlights' %></h2>
-        <ul class="detail-tags">
-          <% shop.highlights.forEach(function(item) { %>
-            <li><%= item %></li>
+        <div class="rate-table">
+          <% pricingTable.forEach(function(block) { %>
+            <div class="rate-table__block">
+              <div class="rate-table__header">
+                <h3><%= block.label %></h3>
+                <% if (block.meta) { %>
+                  <span class="rate-table__meta"><%= block.meta %></span>
+                <% } %>
+              </div>
+              <ul class="rate-table__list">
+                <% (block.prices || []).forEach(function(item) { %>
+                  <li>
+                    <span class="rate-table__person"><%= item.label %></span>
+                    <strong class="rate-table__amount"><%= item.amount %></strong>
+                  </li>
+                <% }) %>
+              </ul>
+            </div>
           <% }) %>
-        </ul>
+        </div>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- move the language selector out of the sticky header into a floating bottom-left widget with updated responsive styling
- remove per-shop description/manager contact blocks and surface pickup/valet service badges alongside address and hours
- replace the contact/highlight cards with fixed before/after 9PM pricing tables and translate the rate data across languages

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68e4c0184520832595b0def8481f7b26