### PR TITLE
Load entry data from static file instead of DB

### DIFF
--- a/controllers/entry/entryController.js
+++ b/controllers/entry/entryController.js
@@ -1,10 +1,10 @@
-const { pool } = require('../../config/db');
 const fs = require('fs');
 const path = require('path');
 const { getContentProtectionMarkup, getSvgContentProtectionElements } = require('./contentProtection');
 
 const COMMUNITY_CHAT_LINK = 'https://open.kakao.com/o/gALpMlRg';
 const COMMUNITY_CONTACT_TEXT = '강남 하퍼 010-5733-8710';
+const STATIC_ENTRY_DATA_PATH = path.resolve(process.cwd(), 'data/entry-static.json');
 const ENTRY_PAGE_TEXT = {
   loading: '출근부 정보를 불러오는 중입니다...',
   error: '출근부 정보를 가져오지 못했습니다. 잠시 후 다시 시도해주세요.',
@@ -195,30 +195,15 @@ function buildTodaySvg(text) {
 }
 
 async function fetchSingleStoreEntries(storeNo, storeRow = null) {
-  let store = storeRow;
-
-  if (!store) {
-    const [[foundStore]] = await pool.query(
-      `SELECT storeNo, storeName
-         FROM INFO_STORE
-        WHERE storeNo=?`,
-      [storeNo]
-    );
-
-    store = foundStore;
-  }
+  const stores = readStaticEntryStores();
+  const store = storeRow || stores.find((entry) => entry.store.storeNo === Number(storeNo))?.store;
 
   if (!store) {
     return null;
   }
 
-  const [entries] = await pool.query(
-    `SELECT workerName, mentionCount, insertCount, createdAt
-         FROM ENTRY_TODAY
-        WHERE storeNo=?
-        ORDER BY createdAt DESC`,
-    [store.storeNo]
-  );
+  const source = stores.find((entry) => entry.store.storeNo === Number(store.storeNo));
+  const entries = source ? source.entries : [];
 
   const ranked = entries.map((entry) => ({
     ...entry,
@@ -231,11 +216,7 @@ async function fetchSingleStoreEntries(storeNo, storeRow = null) {
 }
 
 async function fetchAllStoreEntries() {
-  const [stores] = await pool.query(
-    `SELECT storeNo, storeName
-         FROM INFO_STORE
-        ORDER BY storeNo ASC`
-  );
+  const stores = readStaticEntryStores().map((entry) => entry.store);
 
   const results = [];
 
@@ -252,14 +233,66 @@ async function fetchAllStoreEntries() {
 const ENTRY_ROW_SIZE = 5;
 
 async function fetchStoreMetadata(storeNo) {
-  const [[store]] = await pool.query(
-    `SELECT storeNo, storeName
-       FROM INFO_STORE
-      WHERE storeNo=?`,
-    [storeNo]
-  );
+  const stores = readStaticEntryStores();
+  const store = stores.find((entry) => entry.store.storeNo === Number(storeNo))?.store;
 
   return store || null;
+}
+
+function readStaticEntryStores() {
+  try {
+    const raw = fs.readFileSync(STATIC_ENTRY_DATA_PATH, 'utf8');
+    const parsed = JSON.parse(raw);
+
+    if (!Array.isArray(parsed)) {
+      console.warn('[entryController] Invalid static entry data: root value must be an array.');
+      return [];
+    }
+
+    return parsed
+      .map((store) => {
+        const storeNo = Number(store.storeNo);
+        const storeName = typeof store.storeName === 'string' ? store.storeName.trim() : '';
+
+        if (!Number.isFinite(storeNo) || !storeName) {
+          return null;
+        }
+
+        const entries = Array.isArray(store.entries)
+          ? store.entries
+              .map((entry) => {
+                const workerName = typeof entry.workerName === 'string' ? entry.workerName.trim() : '';
+                if (!workerName) {
+                  return null;
+                }
+
+                return {
+                  workerName,
+                  mentionCount: Math.max(0, Number(entry.mentionCount) || 0),
+                  insertCount: Math.max(0, Number(entry.insertCount) || 0),
+                  createdAt: entry.createdAt || null,
+                };
+              })
+              .filter(Boolean)
+          : [];
+
+        entries.sort((a, b) => {
+          const aTime = new Date(a.createdAt || 0).getTime();
+          const bTime = new Date(b.createdAt || 0).getTime();
+          return bTime - aTime;
+        });
+
+        return {
+          store: { storeNo, storeName },
+          entries,
+        };
+      })
+      .filter(Boolean)
+      .sort((a, b) => a.store.storeNo - b.store.storeNo);
+  } catch (error) {
+    console.warn('[entryController] Failed to load static entry data:', error.message);
+    return [];
+  }
 }
 
 function chunkArray(items, size) {

--- a/data/entry-static.json
+++ b/data/entry-static.json
@@ -1,0 +1,20 @@
+[
+  {
+    "storeNo": 1,
+    "storeName": "샘플 매장",
+    "entries": [
+      {
+        "workerName": "샘플 멤버A",
+        "mentionCount": 5,
+        "insertCount": 10,
+        "createdAt": "2026-04-25T09:00:00+09:00"
+      },
+      {
+        "workerName": "샘플 멤버B",
+        "mentionCount": 2,
+        "insertCount": 4,
+        "createdAt": "2026-04-25T08:30:00+09:00"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
### Motivation
- Replace runtime DB reads for entry data so the site can expose user-provided/static entry information without querying `INFO_STORE`/`ENTRY_TODAY` tables.

### Description
- Remove DB query usage in `controllers/entry/entryController.js` and switch `fetchSingleStoreEntries`, `fetchAllStoreEntries`, and `fetchStoreMetadata` to load from `data/entry-static.json` via a new `readStaticEntryStores()` helper.
- Add `STATIC_ENTRY_DATA_PATH` constant and robust parsing/validation/sorting logic for entries (normalize fields, sort by `createdAt`, filter invalid rows).
- Preserve existing ranking, top-5 calculation, payload shaping and image/SVG rendering code; only the data source was changed.
- Add a sample `data/entry-static.json` file containing example store and entries to edit for production use.

### Testing
- Ran `node --check controllers/entry/entryController.js` which succeeded.
- Verified the static data parses with `node -e "JSON.parse(require('fs').readFileSync('data/entry-static.json','utf8')); console.log('entry-static.json ok')"` which printed success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed129463608325a5ea76082715aacc)