### PR TITLE
Refactor entry loading into service, add DB-backed entries and shuffling

### DIFF
--- a/controllers/entry/entryController.js
+++ b/controllers/entry/entryController.js
@@ -1,10 +1,10 @@
 const fs = require('fs');
 const path = require('path');
 const { getContentProtectionMarkup, getSvgContentProtectionElements } = require('./contentProtection');
+const { fetchEntriesForStore, readStaticEntryStores: readEntryStoreMetadata } = require('../../services/entryService');
 
 const COMMUNITY_CHAT_LINK = 'https://open.kakao.com/o/gALpMlRg';
 const COMMUNITY_CONTACT_TEXT = '강남 하퍼 010-5733-8710';
-const STATIC_ENTRY_DATA_PATH = path.resolve(process.cwd(), 'data/entry-static.json');
 const ENTRY_PAGE_TEXT = {
   loading: '출근부 정보를 불러오는 중입니다...',
   error: '출근부 정보를 가져오지 못했습니다. 잠시 후 다시 시도해주세요.',
@@ -202,8 +202,7 @@ async function fetchSingleStoreEntries(storeNo, storeRow = null) {
     return null;
   }
 
-  const source = stores.find((entry) => entry.store.storeNo === Number(store.storeNo));
-  const entries = source ? source.entries : [];
+  const entries = await fetchEntriesForStore(store.storeNo);
 
   const ranked = entries.map((entry) => ({
     ...entry,
@@ -240,59 +239,22 @@ async function fetchStoreMetadata(storeNo) {
 }
 
 function readStaticEntryStores() {
-  try {
-    const raw = fs.readFileSync(STATIC_ENTRY_DATA_PATH, 'utf8');
-    const parsed = JSON.parse(raw);
+  return readEntryStoreMetadata()
+    .map((store) => {
+      const storeNo = Number(store.storeNo);
+      const storeName = typeof store.storeName === 'string' ? store.storeName.trim() : '';
 
-    if (!Array.isArray(parsed)) {
-      console.warn('[entryController] Invalid static entry data: root value must be an array.');
-      return [];
-    }
+      if (!Number.isFinite(storeNo) || !storeName) {
+        return null;
+      }
 
-    return parsed
-      .map((store) => {
-        const storeNo = Number(store.storeNo);
-        const storeName = typeof store.storeName === 'string' ? store.storeName.trim() : '';
-
-        if (!Number.isFinite(storeNo) || !storeName) {
-          return null;
-        }
-
-        const entries = Array.isArray(store.entries)
-          ? store.entries
-              .map((entry) => {
-                const workerName = typeof entry.workerName === 'string' ? entry.workerName.trim() : '';
-                if (!workerName) {
-                  return null;
-                }
-
-                return {
-                  workerName,
-                  mentionCount: Math.max(0, Number(entry.mentionCount) || 0),
-                  insertCount: Math.max(0, Number(entry.insertCount) || 0),
-                  createdAt: entry.createdAt || null,
-                };
-              })
-              .filter(Boolean)
-          : [];
-
-        entries.sort((a, b) => {
-          const aTime = new Date(a.createdAt || 0).getTime();
-          const bTime = new Date(b.createdAt || 0).getTime();
-          return bTime - aTime;
-        });
-
-        return {
-          store: { storeNo, storeName },
-          entries,
-        };
-      })
-      .filter(Boolean)
-      .sort((a, b) => a.store.storeNo - b.store.storeNo);
-  } catch (error) {
-    console.warn('[entryController] Failed to load static entry data:', error.message);
-    return [];
-  }
+      return {
+        store: { storeNo, storeName },
+        entries: Array.isArray(store.entries) ? store.entries : [],
+      };
+    })
+    .filter(Boolean)
+    .sort((a, b) => a.store.storeNo - b.store.storeNo);
 }
 
 function chunkArray(items, size) {

--- a/services/entryService.js
+++ b/services/entryService.js
@@ -1,7 +1,9 @@
 const fs = require('fs');
 const path = require('path');
+const { pool } = require('../config/db');
 
 const STATIC_ENTRY_DATA_PATH = path.resolve(process.cwd(), 'data/entry-static.json');
+const ENTRY_DYNAMIC_DISPLAY_LIMIT = 10;
 
 function toNumber(value) {
   const numeric = Number(value);
@@ -31,9 +33,13 @@ function normalizeEntry(row) {
     return null;
   }
 
-  const workerName = typeof row.workerName === 'string' ? row.workerName : '';
-  const mentionCount = toNumber(row.mentionCount ?? row.mentions ?? row.mention);
-  const insertCount = toNumber(row.insertCount ?? row.inserts ?? row.insert);
+  const workerName = typeof row.workerName === 'string' ? row.workerName.trim() : '';
+  if (!workerName) {
+    return null;
+  }
+
+  const mentionCount = Math.max(0, toNumber(row.mentionCount ?? row.mentions ?? row.mention));
+  const insertCount = Math.max(0, toNumber(row.insertCount ?? row.inserts ?? row.insert));
   const createdAt = toDate(row.createdAt ?? row.timestamp ?? row.loggedAt);
 
   return {
@@ -44,27 +50,112 @@ function normalizeEntry(row) {
   };
 }
 
+function shuffleEntries(entries) {
+  const shuffled = [...entries];
+
+  for (let index = shuffled.length - 1; index > 0; index -= 1) {
+    const randomIndex = Math.floor(Math.random() * (index + 1));
+    [shuffled[index], shuffled[randomIndex]] = [shuffled[randomIndex], shuffled[index]];
+  }
+
+  return shuffled;
+}
+
+function limitEntries(entries, limit = ENTRY_DYNAMIC_DISPLAY_LIMIT) {
+  const normalizedLimit = Number(limit);
+  if (!Number.isFinite(normalizedLimit) || normalizedLimit <= 0) {
+    return [];
+  }
+
+  return entries.slice(0, normalizedLimit);
+}
+
+function readStaticEntryStores() {
+  try {
+    const raw = fs.readFileSync(STATIC_ENTRY_DATA_PATH, 'utf8');
+    const parsed = JSON.parse(raw);
+
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed
+      .map((store) => {
+        const storeNo = Number(store.storeNo);
+        const storeName = typeof store.storeName === 'string' ? store.storeName.trim() : '';
+        if (!Number.isFinite(storeNo)) {
+          return null;
+        }
+
+        const entries = Array.isArray(store.entries)
+          ? store.entries.map(normalizeEntry).filter(Boolean)
+          : [];
+
+        return {
+          storeNo,
+          storeName,
+          entries,
+        };
+      })
+      .filter(Boolean);
+  } catch (error) {
+    return [];
+  }
+}
+
+function fetchStaticEntriesForStore(storeNo) {
+  const normalizedStoreNo = Number(storeNo);
+  if (!Number.isFinite(normalizedStoreNo) || normalizedStoreNo <= 0) {
+    return [];
+  }
+
+  const matchedStore = readStaticEntryStores().find((store) => store.storeNo === normalizedStoreNo);
+  return matchedStore && Array.isArray(matchedStore.entries) ? matchedStore.entries : [];
+}
+
+async function fetchDatabaseEntriesForStore(storeNo) {
+  const normalizedStoreNo = Number(storeNo);
+  if (!Number.isFinite(normalizedStoreNo) || normalizedStoreNo <= 0) {
+    return [];
+  }
+
+  if (!pool || typeof pool.query !== 'function') {
+    return [];
+  }
+
+  const requiredEnv = [process.env.DB_HOST, process.env.DB_USER, process.env.DB_NAME];
+
+  if (requiredEnv.some((value) => !value)) {
+    return [];
+  }
+
+  try {
+    const [rows] = await pool.query(
+      `SELECT workerName, mentionCount, insertCount, createdAt
+         FROM ENTRY_TODAY
+        WHERE storeNo=?
+        ORDER BY createdAt DESC`,
+      [normalizedStoreNo]
+    );
+
+    return Array.isArray(rows) ? rows.map(normalizeEntry).filter(Boolean) : [];
+  } catch (error) {
+    return [];
+  }
+}
+
 async function fetchEntriesForStore(storeNo, options = {}) {
   const normalizedStoreNo = Number(storeNo);
   if (!Number.isFinite(normalizedStoreNo) || normalizedStoreNo <= 0) {
     return [];
   }
 
-  const stores = readStaticEntryStores();
-  const matchedStore = stores.find((store) => store.storeNo === normalizedStoreNo);
+  const dynamicDisplayLimit = options.limit ?? ENTRY_DYNAMIC_DISPLAY_LIMIT;
+  const staticEntries = fetchStaticEntriesForStore(normalizedStoreNo);
+  const databaseEntries = await fetchDatabaseEntriesForStore(normalizedStoreNo);
+  const limitedDatabaseEntries = limitEntries(shuffleEntries(databaseEntries), dynamicDisplayLimit);
 
-  if (!matchedStore || !Array.isArray(matchedStore.entries)) {
-    return [];
-  }
-
-  return matchedStore.entries
-    .map(normalizeEntry)
-    .filter(Boolean)
-    .sort((a, b) => {
-      const aTime = a.createdAt instanceof Date ? a.createdAt.getTime() : 0;
-      const bTime = b.createdAt instanceof Date ? b.createdAt.getTime() : 0;
-      return bTime - aTime;
-    });
+  return shuffleEntries([...staticEntries, ...limitedDatabaseEntries]);
 }
 
 async function fetchEntryWorkerNames(storeNo, options = {}) {
@@ -85,35 +176,8 @@ async function fetchEntryWorkerNames(storeNo, options = {}) {
 }
 
 module.exports = {
+  ENTRY_DYNAMIC_DISPLAY_LIMIT,
   fetchEntriesForStore,
   fetchEntryWorkerNames,
+  readStaticEntryStores,
 };
-
-function readStaticEntryStores() {
-  try {
-    const raw = fs.readFileSync(STATIC_ENTRY_DATA_PATH, 'utf8');
-    const parsed = JSON.parse(raw);
-
-    if (!Array.isArray(parsed)) {
-      return [];
-    }
-
-    return parsed
-      .map((store) => {
-        const storeNo = Number(store.storeNo);
-        if (!Number.isFinite(storeNo)) {
-          return null;
-        }
-
-        const entries = Array.isArray(store.entries) ? store.entries : [];
-
-        return {
-          storeNo,
-          entries,
-        };
-      })
-      .filter(Boolean);
-  } catch (error) {
-    return [];
-  }
-}


### PR DESCRIPTION
### Motivation
- Decouple controller logic from filesystem parsing and move entry normalization to a dedicated service layer for clearer separation of concerns.
- Support dynamically loaded entries from the database in addition to static data and apply display limits and randomization for dynamic entries.
- Simplify controller code by delegating entry fetching, normalization, and worker name extraction to `entryService`.

### Description
- Added and expanded `services/entryService.js` to normalize entries (`normalizeEntry`), read static stores (`readStaticEntryStores`), fetch static entries (`fetchStaticEntriesForStore`), fetch database entries (`fetchDatabaseEntriesForStore`), combine/limit/shuffle entries (`fetchEntriesForStore`, `shuffleEntries`, `limitEntries`) and expose `fetchEntryWorkerNames` and `ENTRY_DYNAMIC_DISPLAY_LIMIT`.
- Implemented a safe DB query path that uses the configured `pool` and environment checks to read `ENTRY_TODAY` rows when available, falling back to static data when not present in `fetchEntriesForStore`.
- Updated `controllers/entry/entryController.js` to import `fetchEntriesForStore` and `readStaticEntryStores` (aliased as `readEntryStoreMetadata`) and remove direct static file reads by delegating to the service; adapted `fetchSingleStoreEntries`, `fetchAllStoreEntries`, and `readStaticEntryStores` wrapper to use service-provided data.
- Normalization responsibilities were moved into the service so the controller now receives trimmed and validated `workerName`, `mentionCount`, `insertCount`, and `createdAt` values and uses them to build rows and top lists.

### Testing
- Ran the project's automated test suite with `npm test`, and all tests completed successfully.
- Ran the linter with `npm run lint` and no new warnings or errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb5dd339088325b0d70ff10d719d51)