### PR TITLE
Use Kakao Maps for shop location guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ npm run dev
 
 서버는 기본적으로 `http://localhost:3000` 에서 실행됩니다.
 
+## 지도 설정
+
+- 상세 페이지의 위치안내 지도는 카카오맵 JavaScript SDK를 우선 사용합니다. 카카오 개발자 콘솔에서 JavaScript 키를 발급받아 `KAKAO_MAP_APP_KEY` 환경 변수로 설정하세요.
+- 호환성을 위해 `KAKAO_MAP_API_KEY`, `KAKAO_JAVASCRIPT_KEY` 이름도 지원합니다. 키가 없으면 기존 Leaflet 지도로 대체됩니다.
+- 좌표가 없는 업소의 서버 측 주소 보정 및 정적 지도 미리보기에는 기존 네이버 지도 환경 변수(`NAVER_MAP_API_KEY_ID`, `NAVER_MAP_API_KEY`)가 계속 사용될 수 있습니다.
+
 ## 로깅
 
 - 모든 HTTP 요청은 `data/request_logs.jsonl` 파일에 JSON Lines 형태로 저장됩니다. 각 라인은 요청 시각, IP, User-Agent,

--- a/app.js
+++ b/app.js
@@ -10,6 +10,7 @@ const entryRoutes = require('./routes/entry');
 const protectedEntryRoutes = require('./routes/protectedEntries');
 const { initializeDataStore } = require('./services/dataStore');
 const { getNaverMapCredentials } = require('./config/naver');
+const { getKakaoMapAppKey } = require('./config/kakao');
 
 initializeDataStore();
 
@@ -43,6 +44,7 @@ app.use(languageMiddleware);
 app.use((req, res, next) => {
   const { clientId } = getNaverMapCredentials();
   res.locals.naverMapClientId = clientId || '';
+  res.locals.kakaoMapAppKey = getKakaoMapAppKey();
   next();
 });
 app.use('/shops', protectedEntryRoutes);

--- a/config/kakao.js
+++ b/config/kakao.js
@@ -1,0 +1,25 @@
+function resolveValue(...candidates) {
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string') {
+      const trimmed = candidate.trim();
+
+      if (trimmed) {
+        return trimmed;
+      }
+    }
+  }
+
+  return '';
+}
+
+function getKakaoMapAppKey() {
+  return resolveValue(
+    process.env.KAKAO_MAP_APP_KEY,
+    process.env.KAKAO_MAP_API_KEY,
+    process.env.KAKAO_JAVASCRIPT_KEY
+  );
+}
+
+module.exports = {
+  getKakaoMapAppKey,
+};

--- a/public/scripts/pages/shop-detail.js
+++ b/public/scripts/pages/shop-detail.js
@@ -425,15 +425,15 @@
     const hasPresetCoordinates = Number.isFinite(presetLat) && Number.isFinite(presetLng);
     const hasLeaflet = Boolean(window.L && typeof window.L.map === 'function');
     let mapInitialized = false;
-    let naverRetryHandle = null;
-    let naverRetryCount = 0;
-    let naverReadyListenerAttached = false;
+    let kakaoRetryHandle = null;
+    let kakaoRetryCount = 0;
+    let kakaoLoadRequested = false;
     let mapRequestStartTime = null;
     let geocodeRequestStartTime = null;
     let currentMapAttempt = 0;
-    const maxNaverRetries = 30;
+    const maxKakaoRetries = 30;
     const staleAttemptErrorMessage = 'Map load cancelled due to a newer request.';
-    let activeNaverMap = null;
+    let activeKakaoMap = null;
     let activeLeafletMap = null;
 
     function now() {
@@ -531,9 +531,9 @@
       initializeInteractiveMap(reason, { attemptId: currentMapAttempt, newAttempt: true });
     }
 
-    function getNaverMaps() {
-      const maps = window.naver && window.naver.maps;
-      if (!maps || !maps.Service || !maps.LatLng) {
+    function getKakaoMaps() {
+      const maps = window.kakao && window.kakao.maps;
+      if (!maps || !maps.Map || !maps.LatLng || !maps.services || !maps.services.Geocoder) {
         return null;
       }
 
@@ -592,10 +592,10 @@
       });
     }
 
-    function clearNaverRetry() {
-      if (naverRetryHandle !== null) {
-        window.clearTimeout(naverRetryHandle);
-        naverRetryHandle = null;
+    function clearKakaoRetry() {
+      if (kakaoRetryHandle !== null) {
+        window.clearTimeout(kakaoRetryHandle);
+        kakaoRetryHandle = null;
       }
     }
 
@@ -609,22 +609,7 @@
       }
       activeLeafletMap = null;
 
-      if (activeNaverMap) {
-        if (typeof activeNaverMap.destroy === 'function') {
-          try {
-            activeNaverMap.destroy();
-          } catch (error) {
-            warn('Failed to destroy existing Naver map instance.', error);
-          }
-        } else if (typeof activeNaverMap.setMap === 'function') {
-          try {
-            activeNaverMap.setMap(null);
-          } catch (error) {
-            warn('Failed to detach existing Naver map instance.', error);
-          }
-        }
-      }
-      activeNaverMap = null;
+      activeKakaoMap = null;
     }
 
     function resetMapContainer() {
@@ -643,52 +628,36 @@
       }
     }
 
-    function scheduleNaverRetry() {
-      if (mapInitialized || naverRetryHandle !== null || naverRetryCount >= maxNaverRetries) {
+    function scheduleKakaoRetry() {
+      if (mapInitialized || kakaoRetryHandle !== null || kakaoRetryCount >= maxKakaoRetries) {
         return false;
       }
 
       const attemptId = currentMapAttempt;
 
-      naverRetryHandle = window.setTimeout(() => {
-        naverRetryHandle = null;
-        naverRetryCount += 1;
-        initializeInteractiveMap('naver retry', { attemptId });
+      kakaoRetryHandle = window.setTimeout(() => {
+        kakaoRetryHandle = null;
+        kakaoRetryCount += 1;
+        initializeInteractiveMap('kakao retry', { attemptId });
       }, 200);
 
-      logTiming(`Waiting for Naver Maps to become available (attempt ${naverRetryCount + 1} of ${maxNaverRetries}).`);
+      logTiming(`Waiting for Kakao Maps to become available (attempt ${kakaoRetryCount + 1} of ${maxKakaoRetries}).`);
       return true;
     }
 
-    function attachNaverReadyListener() {
-      if (naverReadyListenerAttached) {
+    function requestKakaoLoad() {
+      const maps = window.kakao && window.kakao.maps;
+
+      if (kakaoLoadRequested || !maps || typeof maps.load !== 'function') {
         return;
       }
 
-      const naverGlobal = window.naver && window.naver.maps;
-
-      if (!naverGlobal || typeof naverGlobal !== 'object') {
-        return;
-      }
-
-      const existingHandler =
-        typeof naverGlobal.onJSContentLoaded === 'function' ? naverGlobal.onJSContentLoaded : null;
-
-      naverGlobal.onJSContentLoaded = function onJSContentLoadedWrapper() {
-        if (typeof existingHandler === 'function') {
-          try {
-            existingHandler();
-          } catch (error) {
-            warn('Existing onJSContentLoaded handler failed.', error);
-          }
-        }
-
+      kakaoLoadRequested = true;
+      maps.load(() => {
         if (!mapInitialized) {
-          initializeInteractiveMap('naver script ready');
+          initializeInteractiveMap('kakao script ready');
         }
-      };
-
-      naverReadyListenerAttached = true;
+      });
     }
 
     function handleError(message) {
@@ -856,42 +825,36 @@
 
       activeLeafletMap = map;
       mapInitialized = true;
-      clearNaverRetry();
+      clearKakaoRetry();
       setMapState('ready');
       finalizeMapReady('Leaflet');
       return true;
     }
 
-    function renderNaverMap(lat, lng, attemptId) {
-      const naverMaps = getNaverMaps();
-      if (!naverMaps || !mapContainer || !Number.isFinite(lat) || !Number.isFinite(lng)) {
+    function renderKakaoMap(lat, lng, attemptId) {
+      const kakaoMaps = getKakaoMaps();
+      if (!kakaoMaps || !mapContainer || !Number.isFinite(lat) || !Number.isFinite(lng)) {
         return false;
       }
 
       if (isStaleAttempt(attemptId)) {
-        logTiming('Ignoring Naver map render request for a stale attempt.');
+        logTiming('Ignoring Kakao map render request for a stale attempt.');
         return false;
       }
 
       clearStaticMapArtifacts();
       mapContainer.innerHTML = '';
 
-      const center = new naverMaps.LatLng(lat, lng);
-      const map = new naverMaps.Map(mapContainer, {
+      const center = new kakaoMaps.LatLng(lat, lng);
+      const map = new kakaoMaps.Map(mapContainer, {
         center,
-        zoom: 16,
-        scaleControl: false,
-        mapDataControl: false,
-        logoControlOptions: {
-          position: naverMaps.Position.BOTTOM_RIGHT,
-        },
-        zoomControl: true,
-        zoomControlOptions: {
-          position: naverMaps.Position.TOP_RIGHT,
-        },
+        level: 3,
       });
 
-      const marker = new naverMaps.Marker({
+      const zoomControl = new kakaoMaps.ZoomControl();
+      map.addControl(zoomControl, kakaoMaps.ControlPosition.RIGHT);
+
+      const marker = new kakaoMaps.Marker({
         position: center,
         map,
         title: venueName || undefined,
@@ -902,22 +865,18 @@
         infoContent.className = 'shop-map__info-window';
         infoContent.textContent = venueName;
 
-        const infoWindow = new naverMaps.InfoWindow({
+        const infoWindow = new kakaoMaps.InfoWindow({
           content: infoContent,
-          backgroundColor: 'transparent',
-          borderColor: 'transparent',
-          borderWidth: 0,
-          disableAnchor: true,
         });
 
         infoWindow.open(map, marker);
       }
 
-      activeNaverMap = map;
+      activeKakaoMap = map;
       mapInitialized = true;
-      clearNaverRetry();
+      clearKakaoRetry();
       setMapState('ready');
-      finalizeMapReady('Naver Maps');
+      finalizeMapReady('Kakao Maps');
       return true;
     }
 
@@ -954,11 +913,11 @@
       }
 
       beginMapRequest(triggerReason || 'initial load');
-      attachNaverReadyListener();
+      requestKakaoLoad();
 
-      const naverMaps = getNaverMaps();
+      const kakaoMaps = getKakaoMaps();
 
-      if (!naverMaps) {
+      if (!kakaoMaps) {
         if (hasLeaflet && hasPresetCoordinates) {
           renderLeafletMap(presetLat, presetLng, attemptId);
           return;
@@ -971,7 +930,7 @@
             markReady: false,
           });
 
-        if (scheduleNaverRetry()) {
+        if (scheduleKakaoRetry()) {
           if (!renderedStaticFallback) {
             setMapState('loading');
           }
@@ -987,7 +946,7 @@
       }
 
       if (hasPresetCoordinates) {
-        if (!renderNaverMap(presetLat, presetLng, attemptId)) {
+        if (!renderKakaoMap(presetLat, presetLng, attemptId)) {
           if (hasLeaflet && renderLeafletMap(presetLat, presetLng, attemptId)) {
             return;
           }
@@ -1043,18 +1002,14 @@
 
       function geocode(query) {
         return new Promise((resolve, reject) => {
-          naverMaps.Service.geocode({ query }, (serviceStatus, response) => {
-            if (serviceStatus !== naverMaps.Service.Status.OK) {
+          const geocoder = new kakaoMaps.services.Geocoder();
+          geocoder.addressSearch(query, (addresses, serviceStatus) => {
+            if (serviceStatus !== kakaoMaps.services.Status.OK) {
               reject(new Error(`Geocoding failed with status ${serviceStatus}`));
               return;
             }
 
-            const addresses =
-              response && response.v2 && Array.isArray(response.v2.addresses)
-                ? response.v2.addresses
-                : [];
-
-            if (!addresses.length) {
+            if (!Array.isArray(addresses) || !addresses.length) {
               reject(new Error('No geocoding results found.'));
               return;
             }
@@ -1109,7 +1064,7 @@
 
       geocodeNext(geocodeQueue)
         .then((result) => {
-          if (!renderNaverMap(result.lat, result.lng, attemptId)) {
+          if (!renderKakaoMap(result.lat, result.lng, attemptId)) {
             if (hasLeaflet && renderLeafletMap(result.lat, result.lng, attemptId)) {
               return;
             }
@@ -1149,7 +1104,7 @@
     if (!hasInitialStaticMap) {
       setMapState('loading');
     }
-    attachNaverReadyListener();
+    requestKakaoLoad();
     startMapInitialization('initial load');
   }
 

--- a/views/shop.ejs
+++ b/views/shop.ejs
@@ -43,8 +43,8 @@
 
   const primaryImage = highlightGallery.length ? highlightGallery[0] : null;
   const mapText = (t.shop && t.shop.map) || {};
-  const resolvedClientId = typeof naverMapClientId === 'string' ? naverMapClientId.trim() : '';
-  const extraMapStyles = resolvedClientId
+  const resolvedKakaoMapAppKey = typeof kakaoMapAppKey === 'string' ? kakaoMapAppKey.trim() : '';
+  const extraMapStyles = resolvedKakaoMapAppKey
     ? []
     : ['https://unpkg.com/leaflet@1.9.4/dist/leaflet.css'];
   const pricingHighlight = (t.shop && t.shop.pricingHighlight) || {};
@@ -1025,9 +1025,9 @@
   const locationLng = resolvedLocation && Number.isFinite(resolvedLocation.lng) ? resolvedLocation.lng : null;
   const resolvedMapAuthErrorCode = typeof mapAuthErrorCode === 'string' ? mapAuthErrorCode : '';
   const mapAuthErrorMessage =
-    resolvedMapAuthErrorCode === 'NAVER_MAP_AUTH'
+    !resolvedKakaoMapAppKey && resolvedMapAuthErrorCode === 'NAVER_MAP_AUTH'
       ? mapText.authError ||
-        'Naver Maps authentication failed. Please enable the API subscription in your Naver Cloud project.'
+        'Kakao Maps app key is missing. Please configure a Kakao JavaScript map app key.'
       : '';
   const locationInfoItems = [
     shop.name
@@ -1108,9 +1108,9 @@
   </div>
 <%
   const mapScripts = [];
-  if (resolvedClientId) {
-    const encodedClientId = encodeURIComponent(resolvedClientId);
-    mapScripts.push(`https://openapi.map.naver.com/openapi/v3/maps.js?ncpClientId=${encodedClientId}&submodules=geocoder`);
+  if (resolvedKakaoMapAppKey) {
+    const encodedKakaoAppKey = encodeURIComponent(resolvedKakaoMapAppKey);
+    mapScripts.push(`https://dapi.kakao.com/v2/maps/sdk.js?appkey=${encodedKakaoAppKey}&libraries=services&autoload=false`);
   } else {
     mapScripts.push('https://unpkg.com/leaflet@1.9.4/dist/leaflet.js');
   }


### PR DESCRIPTION
### Motivation
- Prefer Kakao Maps JavaScript SDK for the shop detail "location" section and provide a configurable app key so the site can use a locally-appropriate Korean maps provider. 
- Keep a safe fallback to the existing Leaflet static/interactive map behavior when a Kakao key is not present, and preserve server-side address correction/preview logic that may still rely on existing Naver settings. 

### Description
- Add `config/kakao.js` and support environment variables `KAKAO_MAP_APP_KEY`, `KAKAO_MAP_API_KEY`, and `KAKAO_JAVASCRIPT_KEY` to surface a Kakao JavaScript app key. 
- Expose the Kakao key to templates via `res.locals.kakaoMapAppKey` in `app.js`. 
- Update `views/shop.ejs` to load the Kakao SDK (`dapi.kakao.com/v2/maps/sdk.js`) when a key is configured, update the map auth error message, and keep Leaflet CSS/JS as the fallback. 
- Replace client-side Naver-specific logic in `public/scripts/pages/shop-detail.js` with Kakao-aware flows: request/load Kakao SDK, retry scheduling, render Kakao map and marker/infowindow, and perform address lookup with `kakao.maps.services.Geocoder`; fall back to Leaflet/static preview when Kakao is not available. 
- Document the new Kakao map configuration and fallback behavior in `README.md`. 

### Testing
- Ran `node --check public/scripts/pages/shop-detail.js` and `node --check app.js` which passed without syntax errors. 
- Started the server with `KAKAO_MAP_APP_KEY=dummy PORT=3010 node app.js` and verified the rendered shop page includes the Kakao SDK script URL, which succeeded. 
- Started the server without a Kakao key and verified the Leaflet script/CSS are returned as the fallback on the shop page, which also succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43eef4ce508325b5d090e8b5c2fd35)