### PR TITLE
Prefer Kakao maps on shop detail pages

### DIFF
--- a/public/scripts/pages/shop-detail.js
+++ b/public/scripts/pages/shop-detail.js
@@ -424,6 +424,9 @@
       typeof lngValue === 'string' && lngValue.trim() !== '' ? Number.parseFloat(lngValue) : NaN;
     const hasPresetCoordinates = Number.isFinite(presetLat) && Number.isFinite(presetLng);
     const hasLeaflet = Boolean(window.L && typeof window.L.map === 'function');
+    const hasKakaoSdkScript = Boolean(
+      document.querySelector('script[src^="https://dapi.kakao.com/v2/maps/sdk.js"]'),
+    );
     let mapInitialized = false;
     let kakaoRetryHandle = null;
     let kakaoRetryCount = 0;
@@ -923,19 +926,17 @@
           return;
         }
 
+        if (scheduleKakaoRetry()) {
+          setMapState('loading');
+          return;
+        }
+
         const renderedStaticFallback =
           hasPresetCoordinates &&
           renderStaticFallbackMap(presetLat, presetLng, {
             attemptId,
             markReady: false,
           });
-
-        if (scheduleKakaoRetry()) {
-          if (!renderedStaticFallback) {
-            setMapState('loading');
-          }
-          return;
-        }
 
         if (renderedStaticFallback) {
           return;
@@ -1094,6 +1095,7 @@
     }
 
     const hasInitialStaticMap =
+      !hasKakaoSdkScript &&
       hasPresetCoordinates &&
       renderStaticFallbackMap(presetLat, presetLng, {
         attemptId: currentMapAttempt,


### PR DESCRIPTION
### Motivation
- The shop detail page should use the Kakao Maps SDK when available instead of immediately rendering the static `/map/static` image.
- When the Kakao SDK is present it should be given time to initialize and geocode before falling back to a static preview.
- Avoid showing the static fallback on pages that already include the Kakao Maps script to provide a smoother, native map experience.

### Description
- Added detection for the Kakao Maps SDK by checking for a loaded script tag: `document.querySelector('script[src^="https://dapi.kakao.com/v2/maps/sdk.js"]')` and exposed it as `hasKakaoSdkScript` in `public/scripts/pages/shop-detail.js`.
- Reordered fallback logic so `scheduleKakaoRetry()` is checked earlier and the map region stays in a loading state while Kakao initializes, preventing the static image from being rendered first when the SDK exists.
- Restricted the initial static fallback so it is only rendered when the Kakao SDK script is not present (`!hasKakaoSdkScript`), and preserved existing fallback behavior when the SDK never becomes available.
- Changes are confined to `public/scripts/pages/shop-detail.js` and adjust the map initialization and fallback decision flow.

### Testing
- Ran `git diff --check` to validate whitespace and diff sanity; the check passed.
- Ran `node --check public/scripts/pages/shop-detail.js` to validate JS syntax; the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43f16097848325a00a5a047a4368e3)