### PR TITLE
Add KakaoMap location guide links

### DIFF
--- a/data/translations.json
+++ b/data/translations.json
@@ -57,7 +57,10 @@
         "loading": "지도를 불러오는 중입니다...",
         "error": "지도를 불러오지 못했습니다. 주소 정보를 다시 확인해주세요.",
         "authError": "네이버 지도 Open API 인증이 완료되지 않았습니다. 네이버 클라우드 콘솔에서 지도 API 구독과 인증키를 설정해주세요.",
-        "ariaLabel": "{{shopName}}의 지도 위치"
+        "ariaLabel": "{{shopName}}의 지도 위치",
+        "kakaoTitle": "카카오맵 위치안내",
+        "kakaoSearch": "카카오맵에서 보기",
+        "kakaoDirections": "길찾기"
       },
       "pricing": {
         "title": "요금 안내",
@@ -265,7 +268,10 @@
         "loading": "Loading map...",
         "error": "We couldn’t load the map. Please double-check the address information.",
         "authError": "Naver Maps Open API authentication is incomplete. Subscribe to the Maps API and set the key in the Naver Cloud console.",
-        "ariaLabel": "Map showing location of {{shopName}}"
+        "ariaLabel": "Map showing location of {{shopName}}",
+        "kakaoTitle": "KakaoMap location guide",
+        "kakaoSearch": "View on KakaoMap",
+        "kakaoDirections": "Directions"
       },
       "pricing": {
         "title": "Pricing guide",
@@ -489,7 +495,10 @@
         "loading": "正在載入地圖...",
         "error": "無法載入地圖。請再次確認地址資訊。",
         "authError": "Naver 地圖 Open API 驗證尚未完成。請在 Naver Cloud 控制台訂閱地圖 API 並設定認證金鑰。",
-        "ariaLabel": "{{shopName}} 的位置地圖"
+        "ariaLabel": "{{shopName}} 的位置地圖",
+        "kakaoTitle": "KakaoMap 位置指南",
+        "kakaoSearch": "在 KakaoMap 查看",
+        "kakaoDirections": "路线"
       },
       "pricing": {
         "title": "費用指南",
@@ -703,7 +712,10 @@
         "loading": "地図を読み込んでいます…",
         "error": "地図を表示できませんでした。住所情報をご確認ください。",
         "authError": "Naverマップ Open API の認証が完了していません。Naver Cloud コンソールでマップAPIの購読と認証キーを設定してください。",
-        "ariaLabel": "{{shopName}} の位置を示す地図"
+        "ariaLabel": "{{shopName}} の位置を示す地図",
+        "kakaoTitle": "KakaoMap 位置案内",
+        "kakaoSearch": "KakaoMapで見る",
+        "kakaoDirections": "ルート案内"
       },
       "pricing": {
         "title": "料金案内",

--- a/public/styles/components/shop-detail.css
+++ b/public/styles/components/shop-detail.css
@@ -878,6 +878,49 @@
   }
 }
 
+
+.shop-map__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: clamp(1rem, 2vw, 1.5rem);
+}
+
+.shop-map__action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.85rem;
+  padding: 0.8rem 1.15rem;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+  font-weight: 800;
+  text-decoration: none;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.2);
+  transition: transform 0.25s ease, border-color 0.25s ease, background 0.25s ease;
+}
+
+.shop-map__action--primary {
+  border-color: rgba(255, 224, 0, 0.68);
+  background: linear-gradient(135deg, #fee500, #ffd233);
+  color: #181600;
+}
+
+.shop-map__action:hover,
+.shop-map__action:focus-visible {
+  transform: translateY(-2px);
+  border-color: rgba(255, 255, 255, 0.42);
+  background: rgba(255, 255, 255, 0.14);
+}
+
+.shop-map__action--primary:hover,
+.shop-map__action--primary:focus-visible {
+  border-color: rgba(255, 238, 80, 0.9);
+  background: linear-gradient(135deg, #fff16a, #fee500);
+}
+
 .shop-map__map {
   position: relative;
   width: 100%;

--- a/views/shop.ejs
+++ b/views/shop.ejs
@@ -1021,6 +1021,21 @@
   const locationLat = resolvedLocation && Number.isFinite(resolvedLocation.lat) ? resolvedLocation.lat : null;
   const locationLng = resolvedLocation && Number.isFinite(resolvedLocation.lng) ? resolvedLocation.lng : null;
 
+  const kakaoMapTitle = mapText.kakaoTitle || '카카오맵 위치안내';
+  const kakaoMapSearchLabel = mapText.kakaoSearch || '카카오맵에서 보기';
+  const kakaoMapDirectionsLabel = mapText.kakaoDirections || '길찾기';
+  const kakaoMapQuery = [shop.name, shop.address].filter(Boolean).join(' ');
+  const kakaoMapSearchUrl = kakaoMapQuery
+    ? `https://map.kakao.com/?q=${encodeURIComponent(kakaoMapQuery)}`
+    : 'https://map.kakao.com/';
+  const kakaoMapTargetName = encodeURIComponent(shop.name || shop.address || '위치');
+  const kakaoMapPlaceUrl = (locationLat !== null && locationLng !== null)
+    ? `https://map.kakao.com/link/map/${kakaoMapTargetName},${locationLat},${locationLng}`
+    : kakaoMapSearchUrl;
+  const kakaoMapDirectionsUrl = (locationLat !== null && locationLng !== null)
+    ? `https://map.kakao.com/link/to/${kakaoMapTargetName},${locationLat},${locationLng}`
+    : kakaoMapSearchUrl;
+
   const locationInfoItems = [
     shop.name
       ? {
@@ -1070,6 +1085,24 @@
               <% }); %>
             </dl>
           <% } %>
+          <div class="shop-map__actions" aria-label="<%= kakaoMapTitle %>">
+            <a
+              class="shop-map__action shop-map__action--primary"
+              href="<%= kakaoMapPlaceUrl %>"
+              target="_blank"
+              rel="noopener"
+            >
+              <%= kakaoMapSearchLabel %>
+            </a>
+            <a
+              class="shop-map__action"
+              href="<%= kakaoMapDirectionsUrl %>"
+              target="_blank"
+              rel="noopener"
+            >
+              <%= kakaoMapDirectionsLabel %>
+            </a>
+          </div>
           <div
             class="shop-map"
             data-shop-map


### PR DESCRIPTION
### Motivation
- Provide visitors an easy way to open the shop location or get directions in KakaoMap from the shop detail page. 
- Use precise coordinates when available and fall back to a query search when coordinates are missing. 
- Surface localized, accessible labels for the KakaoMap actions and match the site styling.

### Description
- Generate KakaoMap URLs and labels in the shop template by adding `kakaoMapPlaceUrl`, `kakaoMapDirectionsUrl`, and related label variables in `views/shop.ejs`, using coordinates when present and falling back to a search URL. 
- Insert two action buttons (“View on KakaoMap” and “Directions”) into the location section markup in `views/shop.ejs`. 
- Add styles for the new buttons in `public/styles/components/shop-detail.css` (`.shop-map__actions`, `.shop-map__action`, `.shop-map__action--primary`) to match the shop detail UI. 
- Add localized labels for Korean/English/Chinese/Japanese under the `shop.map` keys in `data/translations.json`. 
- Keeps existing map/address rendering intact and only augments the UI with direct KakaoMap actions.

### Testing
- Compiled the EJS template with `node -e "const ejs=require('ejs'); ejs.compile(require('fs').readFileSync('views/shop.ejs','utf8'),{filename:'views/shop.ejs'}); console.log('compiled')"` and the compile succeeded. 
- Launched the server with `node app.js` and verified a shop detail page renders the KakaoMap links. 
- Verified the rendered HTML contains the expected KakaoMap links and action classes using `curl` and `rg` (checked for `map.kakao.com/link/map`, `map.kakao.com/link/to`, and `shop-map__action`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43fa7045c883258fa260b1b9ba9be4)