### PR TITLE
Add Kakao Maps integration to shop detail page with server-side key injection

### DIFF
--- a/controllers/shopController.js
+++ b/controllers/shopController.js
@@ -262,6 +262,7 @@ async function renderShopDetail(req, res, next) {
       seoKeywords: Array.isArray(localizedShop.seoKeywords) ? localizedShop.seoKeywords : [],
       pageTitle: `${localizedShop.name}${(res.locals.t.meta && res.locals.t.meta.shopTitleSuffix) || ''}`,
       metaDescription: localizedShop.description || '',
+      kakaoMapAppKey: process.env.KAKAO_MAP_APP_KEY || '',
     });
   } catch (error) {
     next(error);

--- a/public/scripts/pages/shop-detail.js
+++ b/public/scripts/pages/shop-detail.js
@@ -442,6 +442,16 @@
       return element;
     }
 
+
+    function escapeHtml(value) {
+      return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+    }
+
     function renderAddressMap() {
       if (!mapContainer) {
         return;
@@ -487,7 +497,66 @@
       setMapState('ready');
     }
 
-    renderAddressMap();
+    function renderKakaoMap() {
+      if (!mapContainer || !hasCoordinates || !window.kakao || !window.kakao.maps) {
+        return false;
+      }
+
+      function initializeMap() {
+        const kakaoMaps = window.kakao.maps;
+        const position = new kakaoMaps.LatLng(lat, lng);
+
+        mapContainer.innerHTML = '';
+
+        const map = new kakaoMaps.Map(mapContainer, {
+          center: position,
+          level: 3,
+        });
+
+        const marker = new kakaoMaps.Marker({
+          map,
+          position,
+        });
+
+        if (venueName || address) {
+          const infoContent = [
+            '<div class="shop-map__kakao-info">',
+            venueName ? `<strong>${escapeHtml(venueName)}</strong>` : '',
+            address ? `<span>${escapeHtml(address)}</span>` : '',
+            '</div>',
+          ].join('');
+
+          const infoWindow = new kakaoMaps.InfoWindow({
+            content: infoContent,
+            removable: false,
+          });
+
+          infoWindow.open(map, marker);
+        }
+
+        map.addControl(new kakaoMaps.ZoomControl(), kakaoMaps.ControlPosition.RIGHT);
+        map.addControl(new kakaoMaps.MapTypeControl(), kakaoMaps.ControlPosition.TOPRIGHT);
+
+        setMapState('ready');
+
+        window.setTimeout(() => {
+          map.relayout();
+          map.setCenter(position);
+        }, 0);
+      }
+
+      if (typeof window.kakao.maps.load === 'function') {
+        window.kakao.maps.load(initializeMap);
+      } else {
+        initializeMap();
+      }
+
+      return true;
+    }
+
+    if (!renderKakaoMap()) {
+      renderAddressMap();
+    }
   }
 
   const sectionNav = document.querySelector('[data-section-nav]');

--- a/public/styles/components/shop-detail.css
+++ b/public/styles/components/shop-detail.css
@@ -893,6 +893,30 @@
   filter: saturate(1);
 }
 
+
+.shop-map__kakao-info {
+  min-width: 10rem;
+  padding: 0.65rem 0.85rem;
+  color: #1f2933;
+  line-height: 1.45;
+}
+
+.shop-map__kakao-info strong,
+.shop-map__kakao-info span {
+  display: block;
+}
+
+.shop-map__kakao-info strong {
+  font-size: 0.95rem;
+  font-weight: 800;
+}
+
+.shop-map__kakao-info span {
+  margin-top: 0.25rem;
+  font-size: 0.82rem;
+  color: #52606d;
+}
+
 .shop-map__address-panel {
   position: absolute;
   inset: 0;

--- a/views/shop.ejs
+++ b/views/shop.ejs
@@ -1021,6 +1021,7 @@
   const locationLat = resolvedLocation && Number.isFinite(resolvedLocation.lat) ? resolvedLocation.lat : null;
   const locationLng = resolvedLocation && Number.isFinite(resolvedLocation.lng) ? resolvedLocation.lng : null;
 
+
   const locationInfoItems = [
     shop.name
       ? {
@@ -1079,6 +1080,7 @@
             data-shop-district="<%= shop.district %>"
             data-shop-region="<%= shop.region %>"
             data-map-locale="<%= lang || 'ko' %>"
+            data-map-provider="kakao"
             <% if (locationLat !== null && locationLng !== null) { %>
               data-shop-lat="<%= locationLat %>"
               data-shop-lng="<%= locationLng %>"
@@ -1096,7 +1098,11 @@
     </section>
   </div>
 <%
-  const mapScripts = ['/scripts/pages/shop-detail.js'];
+  const mapScripts = [];
+  if (typeof kakaoMapAppKey === 'string' && kakaoMapAppKey.trim()) {
+    mapScripts.push(`https://dapi.kakao.com/v2/maps/sdk.js?appkey=${encodeURIComponent(kakaoMapAppKey.trim())}&autoload=false`);
+  }
+  mapScripts.push('/scripts/pages/shop-detail.js');
   const trackingPixelByShopId = {
     '강남-달리는토끼-하이퍼블릭': 'au_4_1',
     '강남-엘리트(사라있네)-하이퍼블릭': 'au_4_2',


### PR DESCRIPTION
### Motivation
- Provide a richer map experience on the shop detail page by using the Kakao Maps SDK when coordinates are available and an API key is configured. 
- Fall back to the existing address panel when Kakao Maps cannot be used so the UI remains functional.

### Description
- Inject the Kakao Maps API key into the template locals via `kakaoMapAppKey` in `renderShopDetail` so the view can conditionally load the SDK from the server side. 
- Update `views/shop.ejs` to mark the map provider with `data-map-provider="kakao"` and to prepend the Kakao SDK script URL to `mapScripts` when `kakaoMapAppKey` is present, before including the page script. 
- Implement `renderKakaoMap` and an `escapeHtml` helper in `public/scripts/pages/shop-detail.js` to initialize the Kakao map, marker, info window, controls, and to safely render text, with a fallback to the existing `renderAddressMap` when Kakao is unavailable. 
- Add minimal styles for Kakao info window in `public/styles/components/shop-detail.css` to match the site look.

### Testing
- No automated tests were run as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43fa7045c883258fa260b1b9ba9be4)