### PR TITLE
Fix shop detail Kakao map variables

### DIFF
--- a/views/shop.ejs
+++ b/views/shop.ejs
@@ -1020,7 +1020,17 @@
   const resolvedLocation = shopLocation && typeof shopLocation === 'object' ? shopLocation : null;
   const locationLat = resolvedLocation && Number.isFinite(resolvedLocation.lat) ? resolvedLocation.lat : null;
   const locationLng = resolvedLocation && Number.isFinite(resolvedLocation.lng) ? resolvedLocation.lng : null;
-
+  const kakaoMapTitle = mapText.kakaoTitle || '카카오맵 위치안내';
+  const kakaoMapSearchLabel = mapText.kakaoSearch || '카카오맵에서 보기';
+  const kakaoMapDirectionsLabel = mapText.kakaoDirections || '길찾기';
+  const kakaoMapQuery = (shop.address || shop.name || '').trim();
+  const kakaoMapPlaceUrl = kakaoMapQuery
+    ? `https://map.kakao.com/link/search/${encodeURIComponent(kakaoMapQuery)}`
+    : 'https://map.kakao.com/';
+  const kakaoMapDirectionsName = encodeURIComponent(shop.name || kakaoMapQuery || 'Destination');
+  const kakaoMapDirectionsUrl = locationLat !== null && locationLng !== null
+    ? `https://map.kakao.com/link/to/${kakaoMapDirectionsName},${locationLat},${locationLng}`
+    : kakaoMapPlaceUrl;
 
   const locationInfoItems = [
     shop.name


### PR DESCRIPTION
### Motivation

- Fix a runtime ReferenceError in the shop detail template where `kakaoMapTitle` (and related Kakao map action variables) were not defined before rendering the location action buttons.
- Ensure the shop detail page reliably renders map action labels and external Kakao map links even when coordinates are missing.

### Description

- Added definitions in `views/shop.ejs` for `kakaoMapTitle`, `kakaoMapSearchLabel`, and `kakaoMapDirectionsLabel` so labels are always available to the template.
- Constructed `kakaoMapQuery`, `kakaoMapPlaceUrl`, `kakaoMapDirectionsName`, and `kakaoMapDirectionsUrl` using `shop.address` or `shop.name` and falling back to a general Kakao search URL when coordinates are not present.
- Placed the new variables above the location actions markup so the action buttons use these values when rendered.
- Verified the EJS template compiles successfully after the change.

### Testing

- Ran template compilation with `ejs.compile` to validate `views/shop.ejs` and it succeeded.
- Started the application and requested the previously failing shop detail URL with `curl`, which returned HTTP 200, indicating the template rendered without the ReferenceError.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4412e61e848325ba68a1d8ebe09217)