### PR TITLE
Fix Pretendard SRI and adplus tracking host

### DIFF
--- a/views/partials/head.ejs
+++ b/views/partials/head.ejs
@@ -106,7 +106,7 @@
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/pretendard@1.3.9/dist/web/static/pretendard.css"
-      integrity="sha256-SCNrFTyiqNASnrDJ/pbWxzuV7x4ho3JjwRZwnGFXAN8="
+      integrity="sha256-dNv5TBqzyx0WY0aHjgNXLYAErIjSGshDMqMrKKCI8r0="
       crossorigin="anonymous"
     />
     <!-- Google tag (gtag.js) -->

--- a/views/shop.ejs
+++ b/views/shop.ejs
@@ -1155,7 +1155,7 @@
   const trackingAdCode = trackingPixelByShopId[shop.id];
 %>
 <% if (trackingAdCode) { %>
-  <img src="https://adplus.store/api/track?adCode=<%= trackingAdCode %>" alt="" style="width:1px;height:1px;border:0;display:none;" />
+  <img src="https://www.adplus.store/api/track?adCode=<%= trackingAdCode %>" alt="" style="width:1px;height:1px;border:0;display:none;" />
 <% } %>
 <%- include('partials/footer', {
   scripts: mapScripts


### PR DESCRIPTION
### Motivation
- The Pretendard stylesheet was being blocked due to an SRI mismatch and the ad tracking pixel request to the non‑www host was timing out, so the templates need to match the actual served resources.

### Description
- Update the Pretendard stylesheet `integrity` value in `views/partials/head.ejs` to the correct SHA‑256 value.
- Change the tracking pixel URL in `views/shop.ejs` from `https://adplus.store/api/track` to `https://www.adplus.store/api/track` to match the working host.

### Testing
- Ran `git diff --check` with no issues reported.
- Compiled the EJS templates with `node -e "const ejs=require('ejs'); for (const f of ['views/partials/head.ejs','views/shop.ejs']) { ejs.compile(require('fs').readFileSync(f,'utf8'), {filename:f}); console.log('compiled', f); }"` and both templates compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a442d910a0c8325bc9c783949b0a444)