### PR TITLE
Fix shop map fallback rendering (static SVG endpoint + client fallback)

### DIFF
--- a/controllers/shopController.js
+++ b/controllers/shopController.js
@@ -144,6 +144,82 @@ function buildSeoKeywords(shops, options = {}) {
   return [...keywords];
 }
 
+
+function escapeXml(value = '') {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function renderShopStaticMap(req, res, next) {
+  try {
+    const shops = getShops();
+    const { shop } = findShopByIdentifier(shops, req.params.id);
+
+    if (!shop) {
+      return next();
+    }
+
+    const lang = res.locals.lang || DEFAULT_LANGUAGE;
+    const localizedShop = localizeShop(shop, lang);
+    const width = Math.min(Math.max(Number.parseInt(req.query.w, 10) || 960, 320), 1600);
+    const height = Math.min(Math.max(Number.parseInt(req.query.h, 10) || 360, 220), 900);
+    const name = localizedShop.name || shop.name || '위치 정보';
+    const address = localizedShop.address || shop.address || '';
+    const region = [localizedShop.region, localizedShop.district].filter(Boolean).join(' · ');
+    const lat = Number.parseFloat(req.query.lat);
+    const lng = Number.parseFloat(req.query.lng);
+    const coordinates = Number.isFinite(lat) && Number.isFinite(lng)
+      ? `${lat.toFixed(6)}, ${lng.toFixed(6)}`
+      : '';
+    const centerX = width / 2;
+    const centerY = height / 2;
+    const pinY = centerY - 34;
+
+    const svg = `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" role="img" aria-labelledby="title desc">
+  <title id="title">${escapeXml(name)} 위치 지도</title>
+  <desc id="desc">${escapeXml(address || region || coordinates || name)}</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#f8fbff"/>
+      <stop offset="1" stop-color="#dfeeff"/>
+    </linearGradient>
+    <pattern id="minorGrid" width="48" height="48" patternUnits="userSpaceOnUse">
+      <path d="M 48 0 L 0 0 0 48" fill="none" stroke="#c8d8ea" stroke-width="1" opacity="0.55"/>
+    </pattern>
+    <filter id="shadow" x="-30%" y="-30%" width="160%" height="170%">
+      <feDropShadow dx="0" dy="10" stdDeviation="8" flood-color="#1f2937" flood-opacity="0.28"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#bg)"/>
+  <rect width="100%" height="100%" fill="url(#minorGrid)"/>
+  <path d="M ${width * 0.08} ${height * 0.22} C ${width * 0.28} ${height * 0.16}, ${width * 0.36} ${height * 0.72}, ${width * 0.62} ${height * 0.58} S ${width * 0.86} ${height * 0.36}, ${width * 0.96} ${height * 0.44}" fill="none" stroke="#ffffff" stroke-width="34" stroke-linecap="round" opacity="0.82"/>
+  <path d="M ${width * 0.08} ${height * 0.22} C ${width * 0.28} ${height * 0.16}, ${width * 0.36} ${height * 0.72}, ${width * 0.62} ${height * 0.58} S ${width * 0.86} ${height * 0.36}, ${width * 0.96} ${height * 0.44}" fill="none" stroke="#f6c453" stroke-width="10" stroke-linecap="round" opacity="0.92"/>
+  <path d="M ${width * 0.18} ${height * 0.92} L ${width * 0.42} ${height * 0.12} M ${width * 0.58} ${height * 0.94} L ${width * 0.78} ${height * 0.1}" stroke="#ffffff" stroke-width="24" stroke-linecap="round" opacity="0.72"/>
+  <path d="M ${width * 0.18} ${height * 0.92} L ${width * 0.42} ${height * 0.12} M ${width * 0.58} ${height * 0.94} L ${width * 0.78} ${height * 0.1}" stroke="#b7c7d9" stroke-width="4" stroke-linecap="round" opacity="0.8"/>
+  <g filter="url(#shadow)">
+    <path d="M ${centerX} ${pinY + 92} C ${centerX - 48} ${pinY + 30}, ${centerX - 38} ${pinY - 34}, ${centerX} ${pinY - 34} C ${centerX + 38} ${pinY - 34}, ${centerX + 48} ${pinY + 30}, ${centerX} ${pinY + 92} Z" fill="#ef4444"/>
+    <circle cx="${centerX}" cy="${pinY + 18}" r="20" fill="#ffffff"/>
+  </g>
+  <g transform="translate(${Math.max(24, centerX - 230)} ${Math.min(height - 122, pinY + 110)})">
+    <rect width="460" height="96" rx="18" fill="#111827" opacity="0.9"/>
+    <text x="24" y="34" font-family="'Noto Sans KR', 'Apple SD Gothic Neo', sans-serif" font-size="22" font-weight="800" fill="#ffffff">${escapeXml(name)}</text>
+    <text x="24" y="62" font-family="'Noto Sans KR', 'Apple SD Gothic Neo', sans-serif" font-size="15" font-weight="600" fill="#d1d5db">${escapeXml(address || region || '카카오맵에서 자세한 위치 확인')}</text>
+    <text x="24" y="83" font-family="'Noto Sans KR', 'Apple SD Gothic Neo', sans-serif" font-size="13" fill="#9ca3af">${escapeXml(coordinates)}</text>
+  </g>
+</svg>`;
+
+    res.set('Cache-Control', 'public, max-age=86400');
+    res.type('image/svg+xml').send(svg);
+  } catch (error) {
+    next(error);
+  }
+}
+
 function renderIndex(req, res) {
   const lang = res.locals.lang || DEFAULT_LANGUAGE;
   const localizedShops = getLocalizedShops(lang);
@@ -345,6 +421,7 @@ function renderSitemap(req, res) {
 module.exports = {
   renderIndex,
   renderShopDetail,
+  renderShopStaticMap,
   renderSitemap,
   renderShopEntrySummary,
 };

--- a/public/scripts/pages/shop-detail.js
+++ b/public/scripts/pages/shop-detail.js
@@ -462,6 +462,27 @@
       return `https://map.kakao.com/link/search/${encodeURIComponent(query)}`;
     }
 
+    function buildStaticMapUrl() {
+      const params = new URLSearchParams();
+      if (hasCoordinates) {
+        params.set('lat', String(lat));
+        params.set('lng', String(lng));
+      }
+      params.set('w', String(Math.max(320, Math.round(mapContainer?.clientWidth || 960))));
+      params.set('h', String(Math.max(220, Math.round(mapContainer?.clientHeight || 360))));
+      return `/shops/${encodeURIComponent(mapHost.dataset.shopId || '')}/map/static?${params.toString()}`;
+    }
+
+    function createStaticMapImage() {
+      const image = document.createElement('img');
+      image.className = 'business-profile-mini-map__image';
+      image.src = buildStaticMapUrl();
+      image.alt = `${venueName || address || '위치'} 지도`;
+      image.loading = 'lazy';
+      image.decoding = 'async';
+      return image;
+    }
+
     function createKakaoMiniMapFallback(message) {
       const link = document.createElement('a');
       link.className = 'business-profile-mini-map-fallback';
@@ -491,6 +512,7 @@
       }
 
       mapContainer.innerHTML = '';
+      mapContainer.appendChild(createStaticMapImage());
       mapContainer.appendChild(createKakaoMiniMapFallback('카카오맵에서 위치를 확인하세요.'));
 
       const panel = document.createElement('div');

--- a/public/styles/components/shop-detail.css
+++ b/public/styles/components/shop-detail.css
@@ -939,25 +939,38 @@
 .business-profile-mini-map {
   background:
     linear-gradient(rgba(18, 15, 38, 0.35), rgba(18, 15, 38, 0.35)),
-    url('http://t1.daumcdn.net/mapjsapi/images/bg_tile.png');
+    linear-gradient(135deg, #e5efff, #f8fbff);
+}
+
+.business-profile-mini-map__image {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
 .business-profile-mini-map-fallback {
   position: absolute;
-  inset: 0;
-  z-index: 0;
+  right: clamp(0.75rem, 2vw, 1rem);
+  bottom: clamp(0.75rem, 2vw, 1rem);
+  z-index: 2;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
-  padding: clamp(1.25rem, 4vw, 2.5rem);
+  max-width: min(22rem, calc(100% - 2rem));
+  padding: 0.85rem 1rem;
   color: #1f2933;
   text-align: center;
   text-decoration: none;
-  background:
-    radial-gradient(circle at 50% 45%, rgba(254, 229, 0, 0.24), transparent 7rem),
-    rgba(255, 255, 255, 0.72);
+  border: 1px solid rgba(255, 255, 255, 0.68);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.22);
+  backdrop-filter: blur(10px);
 }
 
 .business-profile-mini-map-fallback__badge {
@@ -994,7 +1007,7 @@
 .shop-map[data-map-state='fallback'] .shop-map__address-panel {
   z-index: 1;
   pointer-events: none;
-  background: transparent;
+  background: rgba(17, 24, 39, 0.82);
 }
 
 .shop-map__kakao-info {

--- a/routes/index.js
+++ b/routes/index.js
@@ -2,12 +2,14 @@ const express = require('express');
 const {
   renderIndex,
   renderShopDetail,
+  renderShopStaticMap,
   renderSitemap,
 } = require('../controllers/shopController');
 
 const router = express.Router();
 
 router.get('/', renderIndex);
+router.get('/shops/:id/map/static', renderShopStaticMap);
 router.get('/shops/:id', renderShopDetail);
 router.get('/sitemap.xml', renderSitemap);
 


### PR DESCRIPTION
### Motivation
- Prevent the map area on shop detail pages from appearing blank when the Kakao Maps SDK is unavailable by providing a server-side static map and client fallback. 

### Description
- Add a new SVG static map endpoint `renderShopStaticMap` and export it from `controllers/shopController.js`, which generates a responsive SVG using requested `w`/`h` and optional `lat`/`lng`. 
- Register route `GET /shops/:id/map/static` in `routes/index.js` to serve the SVG. 
- Add client-side fallback in `public/scripts/pages/shop-detail.js` with `buildStaticMapUrl` and `createStaticMapImage` so the static image is appended to the map container when Kakao is not available. 
- Update styles in `public/styles/components/shop-detail.css` to render the static image (`.business-profile-mini-map__image`) and change the Kakao link overlay to a compact, readable floating panel. 

### Testing
- Ran syntax checks with `node -c controllers/shopController.js && node -c routes/index.js && node -c public/scripts/pages/shop-detail.js`, which succeeded. 
- Started the app and verified the static map endpoint with `curl -I '<host>/shops/<id>/map/static?lat=...&lng=...&w=1004&h=358'` and received `HTTP/1.1 200 OK` and `Content-Type: image/svg+xml`. 
- Changes were committed (message: `Fix shop map fallback rendering`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a442eeb34b4832583aeebc12acfceca)