### PR TITLE
Render shop address as overlay on map and remove Kakao action buttons

### DIFF
--- a/public/styles/components/shop-detail.css
+++ b/public/styles/components/shop-detail.css
@@ -879,47 +879,6 @@
 }
 
 
-.shop-map__actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-  margin-top: clamp(1rem, 2vw, 1.5rem);
-}
-
-.shop-map__action {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 2.85rem;
-  padding: 0.8rem 1.15rem;
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.08);
-  color: #fff;
-  font-weight: 800;
-  text-decoration: none;
-  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.2);
-  transition: transform 0.25s ease, border-color 0.25s ease, background 0.25s ease;
-}
-
-.shop-map__action--primary {
-  border-color: rgba(255, 224, 0, 0.68);
-  background: linear-gradient(135deg, #fee500, #ffd233);
-  color: #181600;
-}
-
-.shop-map__action:hover,
-.shop-map__action:focus-visible {
-  transform: translateY(-2px);
-  border-color: rgba(255, 255, 255, 0.42);
-  background: rgba(255, 255, 255, 0.14);
-}
-
-.shop-map__action--primary:hover,
-.shop-map__action--primary:focus-visible {
-  border-color: rgba(255, 238, 80, 0.9);
-  background: linear-gradient(135deg, #fff16a, #fee500);
-}
 
 .shop-map__map {
   position: relative;
@@ -1005,9 +964,8 @@
 }
 
 .shop-map[data-map-state='fallback'] .shop-map__address-panel {
-  z-index: 1;
+  z-index: 3;
   pointer-events: none;
-  background: rgba(17, 24, 39, 0.82);
 }
 
 .shop-map__kakao-info {
@@ -1035,26 +993,25 @@
 
 .shop-map__address-panel {
   position: absolute;
-  inset: 0;
+  left: clamp(0.75rem, 2vw, 1rem);
+  bottom: clamp(0.75rem, 2vw, 1rem);
   display: flex;
   align-items: center;
-  justify-content: center;
-  gap: clamp(1rem, 4vw, 2rem);
-  padding: clamp(1.25rem, 4vw, 2.5rem);
-  background:
-    radial-gradient(circle at 50% 45%, rgba(255, 100, 128, 0.22), transparent 0.4rem),
-    linear-gradient(rgba(255, 255, 255, 0.055) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(255, 255, 255, 0.055) 1px, transparent 1px),
-    radial-gradient(circle at top left, rgba(255, 87, 127, 0.24), transparent 38%),
-    linear-gradient(135deg, rgba(39, 28, 73, 0.96), rgba(17, 12, 35, 0.98));
-  background-size: auto, 42px 42px, 42px 42px, auto, auto;
+  gap: clamp(0.75rem, 2vw, 1rem);
+  max-width: min(34rem, calc(100% - 2rem));
+  padding: clamp(0.8rem, 2vw, 1rem);
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  border-radius: 18px;
+  background: rgba(17, 24, 39, 0.78);
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.28);
+  backdrop-filter: blur(10px);
 }
 
 .shop-map__address-pin {
   position: relative;
   flex: 0 0 auto;
-  width: clamp(3.25rem, 10vw, 5rem);
-  height: clamp(3.25rem, 10vw, 5rem);
+  width: clamp(2.4rem, 7vw, 3.4rem);
+  height: clamp(2.4rem, 7vw, 3.4rem);
   border-radius: 50% 50% 50% 0;
   transform: rotate(-45deg);
   background: linear-gradient(135deg, var(--color-primary), var(--color-accent));
@@ -1071,13 +1028,7 @@
 }
 
 .shop-map__address-content {
-  max-width: min(30rem, 100%);
-  padding: clamp(1rem, 3vw, 1.35rem);
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  border-radius: 20px;
-  background: rgba(10, 7, 24, 0.74);
-  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.28);
-  backdrop-filter: blur(10px);
+  max-width: min(28rem, 100%);
 }
 
 .shop-map__address-title,
@@ -1090,14 +1041,14 @@
 
 .shop-map__address-title {
   color: #fff;
-  font-size: clamp(1.25rem, 3vw, 1.8rem);
+  font-size: clamp(1.05rem, 2.4vw, 1.35rem);
   font-weight: 800;
 }
 
 .shop-map__address-line {
   margin-top: 0.55rem;
   color: var(--color-text);
-  font-size: clamp(1rem, 2.2vw, 1.18rem);
+  font-size: clamp(0.92rem, 2vw, 1.05rem);
   font-weight: 700;
   line-height: 1.55;
 }
@@ -1112,7 +1063,6 @@
 
 @media (max-width: 600px) {
   .shop-map__address-panel {
-    flex-direction: column;
-    text-align: center;
+    align-items: flex-start;
   }
 }

--- a/views/shop.ejs
+++ b/views/shop.ejs
@@ -1020,18 +1020,10 @@
   const resolvedLocation = shopLocation && typeof shopLocation === 'object' ? shopLocation : null;
   const locationLat = resolvedLocation && Number.isFinite(resolvedLocation.lat) ? resolvedLocation.lat : null;
   const locationLng = resolvedLocation && Number.isFinite(resolvedLocation.lng) ? resolvedLocation.lng : null;
-  const kakaoMapTitle = mapText.kakaoTitle || '카카오맵 위치안내';
-  const kakaoMapSearchLabel = mapText.kakaoSearch || '카카오맵에서 보기';
-  const kakaoMapDirectionsLabel = mapText.kakaoDirections || '길찾기';
   const kakaoMapQuery = (shop.address || shop.name || '').trim();
   const kakaoMapPlaceUrl = kakaoMapQuery
     ? `https://map.kakao.com/link/search/${encodeURIComponent(kakaoMapQuery)}`
     : 'https://map.kakao.com/';
-  const kakaoMapDirectionsName = encodeURIComponent(shop.name || kakaoMapQuery || 'Destination');
-  const kakaoMapDirectionsUrl = locationLat !== null && locationLng !== null
-    ? `https://map.kakao.com/link/to/${kakaoMapDirectionsName},${locationLat},${locationLng}`
-    : kakaoMapPlaceUrl;
-
   const locationInfoItems = [
     shop.name
       ? {
@@ -1081,24 +1073,6 @@
               <% }); %>
             </dl>
           <% } %>
-          <div class="shop-map__actions" aria-label="<%= kakaoMapTitle %>">
-            <a
-              class="shop-map__action shop-map__action--primary"
-              href="<%= kakaoMapPlaceUrl %>"
-              target="_blank"
-              rel="noopener"
-            >
-              <%= kakaoMapSearchLabel %>
-            </a>
-            <a
-              class="shop-map__action"
-              href="<%= kakaoMapDirectionsUrl %>"
-              target="_blank"
-              rel="noopener"
-            >
-              <%= kakaoMapDirectionsLabel %>
-            </a>
-          </div>
           <div
             class="shop-map"
             data-shop-map


### PR DESCRIPTION
### Motivation
- Improve the shop location UI by removing separate KakaoMap action buttons and making the address visible as an overlay on the map so the map view is the primary location element.
- Avoid a full-screen/fallback address panel that hides the static map image and instead present a compact, readable overlay on top of the map.

### Description
- Removed the standalone Kakao action button block and related EJS variables from `views/shop.ejs` so the location card flows directly into the embedded map area.
- Updated `public/styles/components/shop-detail.css` to delete the `.shop-map__actions` styles and change `.shop-map__address-panel` into a bottom-left overlay with `z-index: 3`, compact paddings, border, rounded corners, shadow and backdrop blur.
- Reduced the fallback pin size and adjusted address typography and container max widths so the address overlay fits the visible map area on desktop and mobile.
- Kept the existing map markup and fallback link inside the map container so the static/fallback map image and KakaoMap fallback link still render.

### Testing
- Compiled the template successfully with `node -e "const ejs=require('ejs'); ejs.compile(require('fs').readFileSync('views/shop.ejs','utf8')); console.log('shop.ejs compiled')"` and it succeeded.
- Launched the app with `PORT=3010 node app.js` and received `HTTP/1.1 200 OK` for a shop page request using `curl -I`, which succeeded.
- Verified the rendered HTML contains the mini-map markup and no longer contains the action buttons by fetching the page and checking with `curl -s <url> | rg 'business-profile-mini-map'` (present) and ensuring `rg 'shop-map__actions|카카오맵에서 보기|길찾기'` returned no matches, which passed.
- Ran static checks (`git diff --check`) and template compilation checks, both of which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4431130d148325bb9116d6304bbf43)