### PR TITLE
Fix shop static map route

### DIFF
--- a/routes/protectedEntries.js
+++ b/routes/protectedEntries.js
@@ -1,8 +1,12 @@
 const express = require('express');
-const { renderShopEntrySummary } = require('../controllers/shopController');
+const {
+  renderShopEntrySummary,
+  renderShopStaticMap,
+} = require('../controllers/shopController');
 
 const router = express.Router();
 
+router.get('/:id/map/static', renderShopStaticMap);
 router.get('/:id/entries.json', renderShopEntrySummary);
 
 module.exports = router;


### PR DESCRIPTION
### Motivation
- Ensure requests to `/shops/:id/map/static` are handled by the router mounted at `/shops` so static SVG map requests do not fall through to the 404 handler.

### Description
- Import `renderShopStaticMap` from `controllers/shopController` and register `router.get('/:id/map/static', renderShopStaticMap)` in `routes/protectedEntries.js`, leaving the existing `/:id/entries.json` route intact.

### Testing
- Started the server with `node app.js` and verified with `curl -fsSI '<server>/shops/<shop-id>/map/static?lat=...&lng=...&w=386&h=278'` which returned `HTTP/1.1 200 OK` and `Content-Type: image/svg+xml`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a443b5e62288325b7a61a457e7f3710)