### PR TITLE
Proxy Adplus tracking pixel

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,6 +9,7 @@ const shopRoutes = require('./routes/index');
 const entryRoutes = require('./routes/entry');
 const protectedEntryRoutes = require('./routes/protectedEntries');
 const { initializeDataStore } = require('./services/dataStore');
+const { trackAdplusVisit } = require('./services/adplusTracker');
 
 initializeDataStore();
 
@@ -38,6 +39,19 @@ app.use((req, _res, next) => {
 });
 app.use(requestLoggingMiddleware);
 app.use(cloudflareBotGuard);
+app.get('/track/adplus', (req, res) => {
+  const adCode = typeof req.query.adCode === 'string' ? req.query.adCode : '';
+
+  trackAdplusVisit(adCode);
+
+  res
+    .status(204)
+    .set({
+      'Cache-Control': 'no-store, max-age=0',
+      'Content-Length': '0',
+    })
+    .end();
+});
 app.use(languageMiddleware);
 app.use('/shops', protectedEntryRoutes);
 app.use('/entry', entryRoutes);

--- a/services/adplusTracker.js
+++ b/services/adplusTracker.js
@@ -1,0 +1,37 @@
+const https = require('https');
+
+const ADPLUS_TRACK_HOST = 'www.adplus.store';
+const ADPLUS_TRACK_PATH = '/api/track';
+const TRACKING_TIMEOUT_MS = 2500;
+
+function trackAdplusVisit(adCode) {
+  if (typeof adCode !== 'string' || !adCode.trim()) {
+    return;
+  }
+
+  const request = https.get(
+    {
+      hostname: ADPLUS_TRACK_HOST,
+      path: `${ADPLUS_TRACK_PATH}?adCode=${encodeURIComponent(adCode.trim())}`,
+      timeout: TRACKING_TIMEOUT_MS,
+      headers: {
+        'User-Agent': 'gangnamking-tracker/1.0',
+      },
+    },
+    (response) => {
+      response.resume();
+    }
+  );
+
+  request.on('timeout', () => {
+    request.destroy();
+  });
+
+  request.on('error', (error) => {
+    console.warn('[adplusTracker] Failed to send tracking pixel:', error.message);
+  });
+}
+
+module.exports = {
+  trackAdplusVisit,
+};

--- a/views/shop.ejs
+++ b/views/shop.ejs
@@ -1114,7 +1114,7 @@
   const trackingAdCode = trackingPixelByShopId[shop.id];
 %>
 <% if (trackingAdCode) { %>
-  <img src="https://www.adplus.store/api/track?adCode=<%= trackingAdCode %>" alt="" style="width:1px;height:1px;border:0;display:none;" />
+  <img src="/track/adplus?adCode=<%= encodeURIComponent(trackingAdCode) %>" alt="" style="width:1px;height:1px;border:0;display:none;" />
 <% } %>
 <%- include('partials/footer', {
   scripts: mapScripts


### PR DESCRIPTION
### Motivation
- Prevent browsers from surfacing third-party connection timeouts for the Adplus tracking pixel by handling the request server-side and returning a fast response to clients.
- Make the external tracking call non-blocking for users and resilient to DNS/network failures by bounding its timeout and logging errors instead of exposing them to the client.

### Description
- Add `services/adplusTracker.js` which sends the Adplus tracking request with `https.get`, uses a `2500ms` timeout, and logs non-fatal errors on failure.
- Add a new local endpoint `GET /track/adplus` in `app.js` that accepts `adCode` query param, triggers `trackAdplusVisit`, and immediately returns `204 No Content` with `Cache-Control: no-store`.
- Update `views/shop.ejs` to replace the direct `https://www.adplus.store/api/track?...` image pixel with a call to the local `/track/adplus?adCode=...` endpoint and use `encodeURIComponent` on the code.

### Testing
- Ran `node --check app.js` which completed successfully.
- Ran `node --check services/adplusTracker.js` which completed successfully.
- Started the server via `npm start` and verified the app started (server log showed it was running).
- Called the new endpoint with `curl -i 'http://127.0.0.1:3000/track/adplus?adCode=au_4_1'` and observed a `204 No Content` response while the server-side tracker logged the external DNS/network error, demonstrating the browser no longer receives the third-party timeout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a443d935bf08325bdf83dbf18ac01a6)