### PR TITLE
Render static shop map fallback initially

### DIFF
--- a/views/shop.ejs
+++ b/views/shop.ejs
@@ -1020,6 +1020,14 @@
   const resolvedLocation = shopLocation && typeof shopLocation === 'object' ? shopLocation : null;
   const locationLat = resolvedLocation && Number.isFinite(resolvedLocation.lat) ? resolvedLocation.lat : null;
   const locationLng = resolvedLocation && Number.isFinite(resolvedLocation.lng) ? resolvedLocation.lng : null;
+  const staticMapParams = new URLSearchParams();
+  if (locationLat !== null && locationLng !== null) {
+    staticMapParams.set('lat', String(locationLat));
+    staticMapParams.set('lng', String(locationLng));
+  }
+  staticMapParams.set('w', '960');
+  staticMapParams.set('h', '360');
+  const staticMapSrc = `/shops/${encodeURIComponent(shop.id || '')}/map/static?${staticMapParams.toString()}`;
   const locationInfoItems = [
     shop.name
       ? {
@@ -1092,7 +1100,15 @@
               title="<%= shop.address %> 카카오맵 미니맵"
               role="img"
               aria-label="<%= formatMapLabel(mapText.ariaLabel || 'Map showing location of {{shopName}}') %>"
-            ></div>
+            >
+              <img
+                class="business-profile-mini-map__image"
+                src="<%= staticMapSrc %>"
+                alt="<%= shop.name || shop.address || '위치' %> 지도"
+                loading="eager"
+                decoding="async"
+              />
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
### Motivation

- Ensure a visible map is rendered immediately during server-side rendering so users see the shop location before the client-side Kakao SDK initializes or in environments where the SDK is unavailable.
- Provide a reliable fallback to the existing `/shops/:id/map/static` SVG generator to avoid a blank map container and reduce perceived load flicker.

### Description

- Build a static map URL server-side in `views/shop.ejs` using available `lat`/`lng` and fixed dimensions (`w=960`, `h=360`) and expose it as `staticMapSrc`.
- Render an eager `<img class="business-profile-mini-map__image">` inside the `.shop-map__map` container with `src` set to the generated static map URL and `decoding="async"` so a static visual is present before client JS runs.
- No changes were made to server route logic; the static SVG generator (`renderShopStaticMap`) is reused as the image source.

### Testing

- Verified `views/shop.ejs` compiles with `node -e "require('ejs').compile(require('fs').readFileSync('views/shop.ejs','utf8'))"` and it succeeded.
- Started the app and fetched the shop detail HTML with `curl` to confirm the injected `<img>` and `data-shop-lat`/`data-shop-lng` attributes are present and correct.
- Sent a `curl -I` request to the static map endpoint to confirm it responds with `200 OK` and `Content-Type: image/svg+xml`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a444164fb348325b0d2a5619d229fff)