### PR TITLE
Use dynamic Kakao map for shop minimap

### DIFF
--- a/public/scripts/pages/shop-detail.js
+++ b/public/scripts/pages/shop-detail.js
@@ -429,34 +429,17 @@
       }
     }
 
-    function buildStaticMapUrl() {
-      const params = new URLSearchParams();
-      if (hasCoordinates()) {
-        params.set('lat', String(lat));
-        params.set('lng', String(lng));
-      }
-      params.set('w', String(Math.max(320, Math.round(mapContainer?.clientWidth || 960))));
-      params.set('h', String(Math.max(220, Math.round(mapContainer?.clientHeight || 360))));
-      return `/shops/${encodeURIComponent(mapHost.dataset.shopId || '')}/map/static?${params.toString()}`;
-    }
-
-    function createStaticMapImage() {
-      const image = document.createElement('img');
-      image.className = 'business-profile-mini-map__image';
-      image.src = buildStaticMapUrl();
-      image.alt = `${venueName || address || '위치'} 지도`;
-      image.loading = 'lazy';
-      image.decoding = 'async';
-      return image;
-    }
-
-    function renderAddressMap() {
+    function renderMapFallback() {
       if (!mapContainer) {
         return;
       }
 
+      const fallback = document.createElement('div');
+      fallback.className = 'business-profile-mini-map__fallback';
+      fallback.textContent = address || district || region || '지도를 불러올 수 없습니다.';
+
       mapContainer.innerHTML = '';
-      mapContainer.appendChild(createStaticMapImage());
+      mapContainer.appendChild(fallback);
       setMapState('fallback');
     }
 
@@ -469,41 +452,32 @@
       const position = new kakaoMaps.LatLng(lat, lng);
       mapContainer.innerHTML = '';
 
-      if (typeof kakaoMaps.StaticMap === 'function') {
-        const staticMarker = new kakaoMaps.Marker({ position });
-        new kakaoMaps.StaticMap(mapContainer, {
-          center: position,
-          level: 3,
-          marker: staticMarker,
-        });
-      } else {
-        const map = new kakaoMaps.Map(mapContainer, {
-          center: position,
-          level: 3,
-          draggable: false,
-          scrollwheel: false,
-          disableDoubleClick: true,
-          disableDoubleClickZoom: true,
-        });
+      const map = new kakaoMaps.Map(mapContainer, {
+        center: position,
+        level: 3,
+        draggable: true,
+        scrollwheel: true,
+        disableDoubleClick: false,
+        disableDoubleClickZoom: false,
+      });
 
-        const mapMarker = new kakaoMaps.Marker({
-          map,
-          position,
-        });
+      const mapMarker = new kakaoMaps.Marker({
+        map,
+        position,
+      });
 
-        if (typeof map.setZoomable === 'function') {
-          map.setZoomable(false);
-        }
-
-        if (venueName || address) {
-          mapMarker.setTitle(venueName || address);
-        }
-
-        window.setTimeout(() => {
-          map.relayout();
-          map.setCenter(position);
-        }, 0);
+      if (venueName || address) {
+        mapMarker.setTitle(venueName || address);
       }
+
+      if (typeof kakaoMaps.ZoomControl === 'function') {
+        map.addControl(new kakaoMaps.ZoomControl(), kakaoMaps.ControlPosition.RIGHT);
+      }
+
+      window.setTimeout(() => {
+        map.relayout();
+        map.setCenter(position);
+      }, 0);
 
       setMapState('ready');
       return true;
@@ -534,7 +508,7 @@
     function initializeKakaoMiniMap() {
       resolveCoordinatesWithKakaoMaps(() => {
         if (!renderKakaoMap()) {
-          renderAddressMap();
+          renderMapFallback();
         }
       });
     }

--- a/public/styles/components/shop-detail.css
+++ b/public/styles/components/shop-detail.css
@@ -901,13 +901,17 @@
     linear-gradient(135deg, #e5efff, #f8fbff);
 }
 
-.business-profile-mini-map__image {
+.business-profile-mini-map__fallback {
   position: absolute;
   inset: 0;
   z-index: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  color: rgba(255, 255, 255, 0.82);
+  font-weight: 700;
+  text-align: center;
 }
 
 .shop-map__kakao-info {

--- a/views/shop.ejs
+++ b/views/shop.ejs
@@ -1088,9 +1088,7 @@
               class="shop-map__map business-profile-mini-map"
               data-map-region
               data-kakao-map-address="<%= shop.address %>"
-              data-kakao-map-chrome-hidden="true"
               title="<%= shop.address %> 카카오맵 미니맵"
-              role="img"
               aria-label="<%= formatMapLabel(mapText.ariaLabel || 'Map showing location of {{shopName}}') %>"
             ></div>
           </div>


### PR DESCRIPTION
### Motivation
- Convert the shop detail minimap from a static image/StaticMap render to a live, interactive Kakao Map so users can pan/zoom and interact with the location.
- Provide a simple, readable fallback when Kakao Maps cannot render instead of serving static map images.
- Clean up markup and styles that were specific to the static image implementation.

### Description
- Replace static map construction and `StaticMap` usage in `public/scripts/pages/shop-detail.js` with `renderKakaoMap()` that creates a `kakao.maps.Map` instance, enables dragging/scrollwheel, and adds a marker and zoom control.
- Add `renderMapFallback()` in `public/scripts/pages/shop-detail.js` to show address/district/region text when Kakao Maps cannot render, and update initialization to use this fallback.
- Remove static-map-only attributes (`data-kakao-map-chrome-hidden` and `role="img"`) from the map container in `views/shop.ejs` and keep the `aria-label` for accessibility.
- Replace the previous static-image CSS with a `.business-profile-mini-map__fallback` text style in `public/styles/components/shop-detail.css` to style the new fallback display.

### Testing
- Ran `node --check app.js` and it completed successfully.
- Ran `node --check public/scripts/pages/shop-detail.js` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44486187248325b1c14b08d4486eef)