### PR TITLE
Add SEO landing pages and routes for /community, /play/live, /business-info

### DIFF
--- a/controllers/shopController.js
+++ b/controllers/shopController.js
@@ -144,6 +144,92 @@ function buildSeoKeywords(shops, options = {}) {
   return [...keywords];
 }
 
+const SEO_LANDING_PAGES = {
+  '/community': {
+    pageTitle: '유흥 커뮤니티 · 룸 조각 · 룸 번개 정보 - 룸빵1번지',
+    metaDescription: '강남 유흥 커뮤니티에서 룸 조각, 룸 번개, 동행 모집, 실시간 후기와 업소 소식을 한 번에 확인하세요.',
+    seoKeywords: ['유흥 커뮤니티', '룸 조각', '룸 번개', '강남 유흥 커뮤니티', '룸 동행', '강남 룸 조각', '강남 룸 번개'],
+    eyebrow: 'Community',
+    heading: '유흥 커뮤니티와 룸 조각 정보를 빠르게 확인하세요',
+    intro: '룸빵1번지는 강남권 유흥 커뮤니티 이용자가 자주 찾는 룸 조각, 룸 번개, 동행 모집, 업소 후기 키워드를 중심으로 필요한 정보를 정리합니다.',
+    primaryTitle: '유흥 커뮤니티 검색자를 위한 안내',
+    primaryBody: '룸 조각과 룸 번개는 방문 인원, 지역, 시간대, 업소 컨디션을 빠르게 맞춰야 합니다. 커뮤니티 페이지에서는 강남권 룸 정보와 예약 상담으로 이어지는 핵심 동선을 제공합니다.',
+    actions: [
+      { label: '업소 목록 보기', href: '/' },
+      { label: '출근부 확인', href: '/play/live', secondary: true },
+    ],
+    keywordGroups: [
+      { title: '커뮤니티 핵심 키워드', body: '검색 노출 강화를 위해 실제 이용자가 찾는 대표 표현을 콘텐츠 안에 자연스럽게 배치했습니다.', keywords: ['유흥 커뮤니티', '룸 조각', '룸 번개'] },
+      { title: '강남권 모임 검색', body: '강남, 논현, 신사, 역삼 등 주요 상권의 모임 수요와 업소 탐색 흐름을 연결합니다.', keywords: ['강남 룸 조각', '논현 룸 번개', '룸 동행'] },
+    ],
+  },
+  '/play/live': {
+    pageTitle: '초이스톡 출근부 · 엔트리 실시간 확인 - 룸빵1번지',
+    metaDescription: '초이스톡 출근부, 엔트리, 실시간 출근 현황과 인기 멤버 정보를 빠르게 확인할 수 있는 라이브 페이지입니다.',
+    seoKeywords: ['초이스톡', '초이스톡 출근부', '출근부', '엔트리', '실시간 출근부', '강남 엔트리', '강남 출근부'],
+    eyebrow: 'Live Entry',
+    heading: '초이스톡 출근부와 엔트리 현황을 한눈에',
+    intro: '초이스톡 출근부, 엔트리, 실시간 출근 현황을 찾는 사용자가 빠르게 가게별 출근 정보를 확인하도록 라이브 안내 페이지를 구성했습니다.',
+    primaryTitle: '출근부·엔트리 검색 최적화',
+    primaryBody: '라이브 페이지는 초이스톡 출근부와 엔트리 키워드를 중심으로 오늘 출근 인원, 매장별 출근부, 인기 멤버 확인 동선을 제공합니다.',
+    actions: [
+      { label: '실시간 엔트리 보기', href: '/entry' },
+      { label: '업소 정보 보기', href: '/business-info', secondary: true },
+    ],
+    keywordGroups: [
+      { title: '출근부 키워드', body: '초이스톡을 통해 출근부와 엔트리를 찾는 검색 의도를 반영했습니다.', keywords: ['초이스톡 출근부', '실시간 출근부', '오늘 출근부'] },
+      { title: '엔트리 키워드', body: '가게별 엔트리와 멤버 현황으로 이어지는 내부 링크를 강화했습니다.', keywords: ['엔트리', '강남 엔트리', '업소 엔트리'] },
+    ],
+  },
+  '/business-info': {
+    pageTitle: '달토 · 달리는토끼 · 유앤미 · 도파민 업체 정보 - 룸빵1번지',
+    metaDescription: '달토, 달리는토끼, 유앤미, 도파민 등 강남 주요 업체명 검색자를 위한 업체 정보와 예약 상담 안내 페이지입니다.',
+    seoKeywords: ['달토', '달리는토끼', '유앤미', '도파민', '강남 달토', '강남 달리는토끼', '강남 유앤미', '강남 도파민'],
+    eyebrow: 'Business Info',
+    heading: '달토·달리는토끼·유앤미·도파민 업체 정보를 비교하세요',
+    intro: '업체명을 직접 검색하는 고객이 상호, 지역, 업종, 예약 상담 정보를 빠르게 찾을 수 있도록 업체 정보 페이지를 최적화했습니다.',
+    primaryTitle: '업체명 검색 상위 노출을 위한 구성',
+    primaryBody: '달토, 달리는토끼, 유앤미, 도파민 등 브랜드 검색어를 제목, 설명, 본문, 키워드 메타와 구조화 데이터에 자연스럽게 반영했습니다.',
+    actions: [
+      { label: '전체 업체 보기', href: '/' },
+      { label: '커뮤니티 보기', href: '/community', secondary: true },
+    ],
+    keywordGroups: [
+      { title: '대표 업체명', body: '브랜드 직접 검색 유입을 위해 사용자가 입력하는 축약명과 전체명을 함께 배치했습니다.', keywords: ['달토', '달리는토끼', '유앤미', '도파민'] },
+      { title: '지역 결합 검색', body: '강남권 상권명과 업체명을 조합한 롱테일 키워드도 함께 노출합니다.', keywords: ['강남 달토', '강남 유앤미', '강남 도파민'] },
+    ],
+  },
+};
+
+function buildAbsoluteUrl(req, pathname) {
+  const host = req.get('host') || 'nightmens.com';
+  const protocol = host.includes('nightmens.com') ? 'https' : req.protocol;
+  return `${protocol}://${host}${pathname}`;
+}
+
+function renderSeoLandingPage(req, res, next) {
+  const page = SEO_LANDING_PAGES[req.path];
+
+  if (!page) {
+    return next();
+  }
+
+  const canonicalUrl = buildAbsoluteUrl(req, req.path);
+  const structuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'WebPage',
+    name: page.pageTitle,
+    description: page.metaDescription,
+    url: canonicalUrl,
+    keywords: page.seoKeywords.join(', '),
+  };
+
+  res.render('seo-landing', {
+    ...page,
+    canonicalUrl,
+    structuredData,
+  });
+}
 
 function escapeXml(value = '') {
   return String(value)
@@ -408,8 +494,10 @@ async function renderShopEntrySummary(req, res, next) {
 function renderSitemap(req, res) {
   const shops = getShops();
   const host = `${req.protocol}://${req.get('host')}`;
+  const seoPaths = Object.keys(SEO_LANDING_PAGES);
   const urls = [
     `${host}/`,
+    ...seoPaths.map((pathname) => `${host}${pathname}`),
     ...shops.map((shop) => `${host}/shops/${encodeURIComponent(shop.id)}`),
   ];
 
@@ -423,6 +511,7 @@ function renderSitemap(req, res) {
 
 module.exports = {
   renderIndex,
+  renderSeoLandingPage,
   renderShopDetail,
   renderShopStaticMap,
   renderSitemap,

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -8,5 +8,8 @@ Disallow: /entry/roommap/
 Disallow: /entry/roommap/*
 Disallow: /entry/roommap/*/data.json
 Disallow: /entry/roommap/*/roomImage
+Allow: /community
+Allow: /play/live
+Allow: /business-info
 Allow: /
-Sitemap: https://roombbang1st.com/sitemap.xml
+Sitemap: https://nightmens.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,13 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset
-      xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://roombbang1st.com/</loc>
+    <loc>https://nightmens.com/</loc>
     <changefreq>daily</changefreq>
     <priority>1.00</priority>
   </url>
   <url>
-    <loc>https://roombbang1st.com/about</loc>
-    <priority>0.8</priority>
+    <loc>https://nightmens.com/community</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.90</priority>
+  </url>
+  <url>
+    <loc>https://nightmens.com/play/live</loc>
+    <changefreq>daily</changefreq>
+    <priority>0.90</priority>
+  </url>
+  <url>
+    <loc>https://nightmens.com/business-info</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.90</priority>
   </url>
 </urlset>

--- a/public/styles/components/seo-landing.css
+++ b/public/styles/components/seo-landing.css
@@ -1,0 +1,113 @@
+.seo-landing {
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.05), rgba(255, 255, 255, 0));
+}
+
+.seo-hero {
+  padding: 64px 0 40px;
+}
+
+.seo-hero__inner {
+  display: grid;
+  gap: 18px;
+  max-width: 920px;
+}
+
+.seo-hero__eyebrow {
+  color: #b45309;
+  font-size: 0.95rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.seo-hero__title {
+  color: #111827;
+  font-size: clamp(2rem, 5vw, 4rem);
+  line-height: 1.1;
+  margin: 0;
+}
+
+.seo-hero__description {
+  color: #4b5563;
+  font-size: 1.12rem;
+  line-height: 1.8;
+  margin: 0;
+}
+
+.seo-hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 10px;
+}
+
+.seo-button {
+  align-items: center;
+  background: #111827;
+  border: 1px solid #111827;
+  border-radius: 999px;
+  color: #fff;
+  display: inline-flex;
+  font-weight: 800;
+  justify-content: center;
+  min-height: 44px;
+  padding: 0 20px;
+  text-decoration: none;
+}
+
+.seo-button--secondary {
+  background: #fff;
+  color: #111827;
+}
+
+.seo-content {
+  padding-top: 20px;
+}
+
+.seo-content__grid {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.seo-card {
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(17, 24, 39, 0.08);
+  border-radius: 24px;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+  padding: 26px;
+}
+
+.seo-card--wide {
+  grid-column: 1 / -1;
+}
+
+.seo-card h2 {
+  color: #111827;
+  font-size: 1.35rem;
+  margin: 0 0 12px;
+}
+
+.seo-card p {
+  color: #4b5563;
+  line-height: 1.8;
+  margin: 0;
+}
+
+.seo-keyword-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  list-style: none;
+  margin: 18px 0 0;
+  padding: 0;
+}
+
+.seo-keyword-list li {
+  background: #f3f4f6;
+  border-radius: 999px;
+  color: #374151;
+  font-weight: 700;
+  padding: 8px 12px;
+}

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const {
   renderIndex,
+  renderSeoLandingPage,
   renderShopDetail,
   renderShopStaticMap,
   renderSitemap,
@@ -9,6 +10,7 @@ const {
 const router = express.Router();
 
 router.get('/', renderIndex);
+router.get(['/community', '/play/live', '/business-info'], renderSeoLandingPage);
 router.get('/shops/:id/map/static', renderShopStaticMap);
 router.get('/shops/:id', renderShopDetail);
 router.get('/sitemap.xml', renderSitemap);

--- a/views/seo-landing.ejs
+++ b/views/seo-landing.ejs
@@ -1,0 +1,40 @@
+<%- include('partials/head', { title: pageTitle, description: metaDescription, seoKeywords, canonicalUrl, extraStyles: ['/styles/components/seo-landing.css'] }) %>
+  <main class="seo-landing">
+    <section class="seo-hero">
+      <div class="container seo-hero__inner">
+        <p class="seo-hero__eyebrow"><%= eyebrow %></p>
+        <h1 class="seo-hero__title"><%= heading %></h1>
+        <p class="seo-hero__description"><%= intro %></p>
+        <div class="seo-hero__actions">
+          <% actions.forEach(function(action) { %>
+            <a class="seo-button <%= action.secondary ? 'seo-button--secondary' : '' %>" href="<%= action.href %>"><%= action.label %></a>
+          <% }) %>
+        </div>
+      </div>
+    </section>
+
+    <section class="section seo-content" aria-labelledby="seo-primary-heading">
+      <div class="container seo-content__grid">
+        <article class="seo-card seo-card--wide">
+          <h2 id="seo-primary-heading"><%= primaryTitle %></h2>
+          <p><%= primaryBody %></p>
+        </article>
+        <% keywordGroups.forEach(function(group) { %>
+          <article class="seo-card">
+            <h2><%= group.title %></h2>
+            <p><%= group.body %></p>
+            <ul class="seo-keyword-list">
+              <% group.keywords.forEach(function(keyword) { %>
+                <li><%= keyword %></li>
+              <% }) %>
+            </ul>
+          </article>
+        <% }) %>
+      </div>
+    </section>
+
+    <script type="application/ld+json">
+      <%- JSON.stringify(structuredData) %>
+    </script>
+  </main>
+<%- include('partials/footer') %>


### PR DESCRIPTION
### Motivation
- Provide dedicated, crawlable landing pages to improve SEO for the requested target paths and keyword sets (`/community`, `/play/live`, `/business-info`).
- Surface target keywords such as community/room-related terms, `초이스톡`/엔트리 (live entry), and specific brand names (`달토`, `달리는토끼`, `유앤미`, `도파민`) in page titles, meta descriptions, visible content and structured data.
- Ensure search engines can discover these pages by updating `robots.txt` and the site `sitemap.xml`.

### Description
- Added an in-controller configuration `SEO_LANDING_PAGES` and a renderer `renderSeoLandingPage` that emits page-specific `title`, `metaDescription`, `seoKeywords`, `canonicalUrl`, and JSON-LD (`structuredData`) for each target path in `controllers/shopController.js`.
- Registered the new routes `['/community','/play/live','/business-info']` to use the new renderer in `routes/index.js` and included those paths in the dynamic sitemap generation in `controllers/shopController.js`.
- Created a reusable EJS template `views/seo-landing.ejs` and supporting stylesheet `public/styles/components/seo-landing.css` to render keyword-focused landing content with CTA links.
- Updated `public/robots.txt` to allow crawling of the new paths and replaced the sitemap host entries in `public/sitemap.xml` to point at the `nightmens.com` domain.

### Testing
- Ran `node --check controllers/shopController.js` and `node --check routes/index.js`, both checks passed. 
- Launched the app and performed automated HTTP checks with `curl` against `/community`, `/play/live`, `/business-info`, and `/sitemap.xml`, and each path returned the expected HTML/XML responses. 
- Executed `git diff --check` (code-check) with no new warnings reported. 
- Attempted `npm test`, which failed because no `test` script is defined in `package.json` (this is a repository-level configuration issue, not a change introduced by this PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44485c0350832596d8e5f4b11c3cc7)