### PR TITLE
Improve SEO: structured metadata, keyword highlights, and JSON-LD

### DIFF
--- a/controllers/shopController.js
+++ b/controllers/shopController.js
@@ -144,6 +144,109 @@ function buildSeoKeywords(shops, options = {}) {
   return [...keywords];
 }
 
+function normalizeKeywords(keywords) {
+  if (!Array.isArray(keywords)) {
+    return [];
+  }
+
+  return keywords
+    .map((keyword) => (typeof keyword === 'string' ? keyword.trim() : ''))
+    .filter(Boolean);
+}
+
+function uniqueKeywords(keywords, limit = 80) {
+  return [...new Set(normalizeKeywords(keywords))].slice(0, limit);
+}
+
+function pickKeywords(keywords, limit = 8) {
+  return uniqueKeywords(keywords, limit);
+}
+
+function buildHomeSeoContent(shops, t = {}) {
+  const meta = t.meta || {};
+  const seo = t.seo || {};
+  const regions = uniqueKeywords(shops.map((shop) => shop.district || shop.region), 6);
+  const categories = uniqueKeywords(shops.map((shop) => shop.category), 4);
+  const featuredShops = uniqueKeywords(shops.map((shop) => shop.name), 6);
+  const keywordHighlights = pickKeywords([
+    ...(Array.isArray(seo.priorityKeywords) ? seo.priorityKeywords : []),
+    ...regions,
+    ...categories,
+    ...featuredShops,
+  ], 12);
+
+  return {
+    title: meta.indexTitle || '룸빵1번지 - 강남 룸빵·하이퍼블릭 최저가 예약',
+    description: meta.description || '강남·논현·역삼 중심 룸빵, 하이퍼블릭, 셔츠룸, 가라오케 정보를 비교하고 예약 혜택을 확인하세요.',
+    heading: seo.homeHeading || '강남 룸빵·하이퍼블릭 최저가 업소 비교',
+    summary: seo.homeSummary || '룸빵1번지는 강남, 논현, 역삼 등 핵심 상권의 검증 업소 정보를 지역·카테고리별로 정리해 빠른 비교와 예약 상담을 돕습니다.',
+    keywordHighlights,
+  };
+}
+
+function buildShopSeoContent(shop, t = {}) {
+  const meta = t.meta || {};
+  const seo = t.seo || {};
+  const regionText = [shop.region, shop.district].filter(Boolean).join(' ');
+  const priorityKeywords = pickKeywords([
+    `${shop.district || shop.region || ''} ${shop.category || ''}`.trim(),
+    `${shop.district || shop.region || ''} ${shop.name || ''}`.trim(),
+    shop.name,
+    shop.category,
+    ...(Array.isArray(shop.seoKeywords) ? shop.seoKeywords : []),
+  ], 10);
+  const titleTemplate = meta.shopTitleTemplate || '{{shopName}} - {{district}} {{category}} 예약 | 룸빵1번지';
+  const descriptionTemplate = meta.shopDescriptionTemplate || '{{region}} {{shopName}} {{category}} 업소 정보, 가격, 위치, 영업시간과 예약 상담을 룸빵1번지에서 확인하세요.';
+  const replacements = {
+    shopName: shop.name || '',
+    district: shop.district || shop.region || '',
+    category: shop.category || '',
+    region: regionText || shop.region || '',
+  };
+  const applyTemplate = (template) => Object.entries(replacements).reduce(
+    (result, [key, value]) => result.replace(new RegExp(`{{\\s*${key}\\s*}}`, 'g'), value),
+    template
+  );
+
+  return {
+    title: applyTemplate(titleTemplate),
+    description: shop.description || applyTemplate(descriptionTemplate),
+    heading: applyTemplate(seo.shopHeading || '{{district}} {{category}} {{shopName}} 상세 정보'),
+    summary: applyTemplate(seo.shopSummary || '{{region}}에 위치한 {{shopName}}의 가격, 위치, 영업시간, 담당자 정보를 한 번에 확인하고 예약 상담을 진행할 수 있습니다.'),
+    keywordHighlights: priorityKeywords,
+  };
+}
+
+function buildOrganizationJsonLd(req, t = {}) {
+  const host = `${req.protocol}://${req.get('host')}`;
+  const meta = t.meta || {};
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    name: meta.siteName || '룸빵1번지',
+    url: `${host}/`,
+    logo: `${host}/images/logo-roompang.png`,
+  };
+}
+
+function buildShopJsonLd(req, shop) {
+  const host = `${req.protocol}://${req.get('host')}`;
+  const url = `${host}/shops/${encodeURIComponent(shop.id)}`;
+  const imageUrl = typeof shop.image === 'string' && shop.image.startsWith('/') ? `${host}${shop.image}` : shop.image;
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'LocalBusiness',
+    name: shop.name,
+    description: shop.description,
+    url,
+    image: imageUrl || undefined,
+    address: shop.address,
+    areaServed: [shop.region, shop.district].filter(Boolean).join(' '),
+    openingHours: shop.hours,
+  };
+}
 
 function escapeXml(value = '') {
   return String(value)
@@ -242,8 +345,12 @@ function renderIndex(req, res) {
       ? res.locals.t.seo.areaKeywords
       : [];
 
+  const homeSeo = buildHomeSeoContent(localizedShops, res.locals.t);
   const seoKeywords = buildSeoKeywords(localizedShops, {
-    extraKeywords: translationSeoKeywords,
+    extraKeywords: [
+      ...translationSeoKeywords,
+      ...homeSeo.keywordHighlights,
+    ],
   });
 
   res.render('index', {
@@ -253,8 +360,10 @@ function renderIndex(req, res) {
     categories: shopsByCategory.map((group) => group.category),
     districtMap,
     seoKeywords,
-    pageTitle: (res.locals.t.meta && res.locals.t.meta.indexTitle) || 'Gangnam King',
-    metaDescription: (res.locals.t.meta && res.locals.t.meta.description) || '',
+    seoContent: homeSeo,
+    pageTitle: homeSeo.title,
+    metaDescription: homeSeo.description,
+    jsonLd: buildOrganizationJsonLd(req, res.locals.t),
   });
 }
 
@@ -334,13 +443,21 @@ async function renderShopDetail(req, res, next) {
       }
     }
 
+    const shopSeo = buildShopSeoContent(localizedShop, res.locals.t);
+    const shopSeoKeywords = uniqueKeywords([
+      ...shopSeo.keywordHighlights,
+      ...(Array.isArray(localizedShop.seoKeywords) ? localizedShop.seoKeywords : []),
+    ]);
+
     res.render('shop', {
       shop: localizedShop,
       entrySummary,
       shopLocation,
-      seoKeywords: Array.isArray(localizedShop.seoKeywords) ? localizedShop.seoKeywords : [],
-      pageTitle: `${localizedShop.name}${(res.locals.t.meta && res.locals.t.meta.shopTitleSuffix) || ''}`,
-      metaDescription: localizedShop.description || '',
+      seoKeywords: shopSeoKeywords,
+      seoContent: shopSeo,
+      pageTitle: shopSeo.title,
+      metaDescription: shopSeo.description,
+      jsonLd: buildShopJsonLd(req, localizedShop),
       kakaoMapAppKey: process.env.KAKAO_MAP_APP_KEY || '',
     });
   } catch (error) {

--- a/data/translations.json
+++ b/data/translations.json
@@ -5,9 +5,11 @@
     "meta": {
       "siteName": "룸빵1번지",
       "defaultTitle": "룸빵1번지",
-      "indexTitle": "룸빵1번지 - 전국 최저가 유흥 플랫폼",
-      "description": "전국 핵심 업소만 선별해 최저가로 연결해드립니다. 예약부터 혜택까지 검증된 컨시어지가 책임집니다.",
-      "shopTitleSuffix": " - 룸빵1번지"
+      "indexTitle": "룸빵1번지 - 강남 룸빵·하이퍼블릭·셔츠룸 최저가 예약",
+      "description": "강남, 논현, 역삼 중심 룸빵·하이퍼블릭·셔츠룸·가라오케 업소를 지역별로 비교하고 최저가 예약 혜택과 담당자 상담을 확인하세요.",
+      "shopTitleSuffix": " - 룸빵1번지",
+      "shopTitleTemplate": "{{shopName}} - {{district}} {{category}} 가격·예약 | 룸빵1번지",
+      "shopDescriptionTemplate": "{{region}} {{shopName}} {{category}} 업소의 가격표, 위치, 영업시간, 담당자 예약 상담 정보를 룸빵1번지에서 확인하세요."
     },
     "header": {
       "languageLabel": "언어",
@@ -203,7 +205,21 @@
         "광진구",
         "도봉구",
         "양천구"
-      ]
+      ],
+      "priorityKeywords": [
+        "강남 룸빵",
+        "강남 하이퍼블릭",
+        "강남 셔츠룸",
+        "강남 가라오케",
+        "논현 룸빵",
+        "역삼 하이퍼블릭",
+        "룸빵 최저가",
+        "룸빵 예약"
+      ],
+      "homeHeading": "강남 룸빵·하이퍼블릭·셔츠룸 최저가 예약 가이드",
+      "homeSummary": "룸빵1번지는 강남, 논현, 역삼 등 핵심 상권의 룸빵·하이퍼블릭·셔츠룸·가라오케 업소를 지역과 카테고리별로 정리해 가격 비교와 빠른 예약 상담을 돕습니다.",
+      "shopHeading": "{{district}} {{category}} {{shopName}} 가격·예약 정보",
+      "shopSummary": "{{region}}에 위치한 {{shopName}}의 가격표, 위치, 영업시간, 담당자 정보를 한 번에 확인하고 룸빵1번지에서 예약 상담을 진행하세요."
     }
   },
   "en": {
@@ -212,9 +228,11 @@
     "meta": {
       "siteName": "Roombbang First",
       "defaultTitle": "Roombbang First",
-      "indexTitle": "Roombbang First – Nationwide lowest-price nightlife platform",
-      "description": "We handpick only the most sought-after venues nationwide and connect you at the lowest rates. Our vetted concierge handles everything from booking to benefits.",
-      "shopTitleSuffix": " – Roombbang First"
+      "indexTitle": "Roombbang 1st - Gangnam Karaoke Lounge & Hyperpublic Reservations",
+      "description": "Compare Gangnam, Nonhyeon, and Yeoksam karaoke lounges, hyperpublic venues, shirt rooms, pricing, location details, and concierge reservation benefits.",
+      "shopTitleSuffix": " – Roombbang First",
+      "shopTitleTemplate": "{{shopName}} - {{district}} {{category}} Pricing & Reservations | Roombbang 1st",
+      "shopDescriptionTemplate": "Check {{region}} {{shopName}} {{category}} pricing, location, hours, and concierge reservation details on Roombbang 1st."
     },
     "header": {
       "languageLabel": "Language",
@@ -430,7 +448,19 @@
         "Gwangjin-gu",
         "Dobong-gu",
         "Yangcheon-gu"
-      ]
+      ],
+      "priorityKeywords": [
+        "Gangnam karaoke lounge",
+        "Gangnam hyperpublic",
+        "Gangnam shirt room",
+        "Nonhyeon lounge",
+        "Yeoksam hyperpublic",
+        "Korea nightlife concierge"
+      ],
+      "homeHeading": "Gangnam Karaoke Lounge, Hyperpublic & Shirt Room Reservation Guide",
+      "homeSummary": "Roombbang 1st organizes vetted Gangnam, Nonhyeon, and Yeoksam nightlife venues by area and category so visitors can compare pricing, locations, and concierge reservation options quickly.",
+      "shopHeading": "{{district}} {{category}} {{shopName}} Pricing & Reservation Details",
+      "shopSummary": "Review pricing, location, hours, and concierge contact details for {{shopName}} in {{region}} before booking through Roombbang 1st."
     }
   },
   "zh": {
@@ -439,9 +469,11 @@
     "meta": {
       "siteName": "房房一番地",
       "defaultTitle": "房房一番地",
-      "indexTitle": "房房一番地 - 全韓最低價夜生活平台",
-      "description": "嚴選全國核心商圈的頂級店家，以最低價格為您媒合。從預約到優惠皆由專業管家全程負責。",
-      "shopTitleSuffix": " – 房房一番地"
+      "indexTitle": "룸빵1번지 - 江南卡拉OK会所与超級公關预约",
+      "description": "比较江南、论岘、驿三核心会所、超級公關、襯衫房与卡拉OK信息，查看价格、位置和预约礼宾优惠。",
+      "shopTitleSuffix": " – 房房一番地",
+      "shopTitleTemplate": "{{shopName}} - {{district}} {{category}} 价格预约 | 룸빵1번지",
+      "shopDescriptionTemplate": "在룸빵1번지查看{{region}}{{shopName}}{{category}}的价格、位置、营业时间与预约礼宾信息。"
     },
     "header": {
       "languageLabel": "語言",
@@ -647,7 +679,19 @@
         "广津区",
         "道峰区",
         "阳川区"
-      ]
+      ],
+      "priorityKeywords": [
+        "江南卡拉OK",
+        "江南超級公關",
+        "江南襯衫房",
+        "论岘会所",
+        "驿三会所",
+        "首尔夜生活预约"
+      ],
+      "homeHeading": "江南卡拉OK会所、超級公關、襯衫房预约指南",
+      "homeSummary": "룸빵1번지按地区与类别整理江南、论岘、驿三核心夜生活会所，帮助用户快速比较价格、位置与礼宾预约信息。",
+      "shopHeading": "{{district}} {{category}} {{shopName}} 价格预约信息",
+      "shopSummary": "查看位于{{region}}的{{shopName}}价格、位置、营业时间和负责人信息，并通过룸빵1번지进行预约咨询。"
     }
   },
   "ja": {
@@ -656,9 +700,11 @@
     "meta": {
       "siteName": "ルンパン一番地",
       "defaultTitle": "ルンパン一番地",
-      "indexTitle": "ルンパン一番地 - 全国最安値ナイトライフプラットフォーム",
-      "description": "全国の主要店舗だけを厳選し、最安値でご案内します。予約から特典まで、検証済みのコンシェルジュが責任を持って対応します。",
-      "shopTitleSuffix": " – ルンパン一番地"
+      "indexTitle": "룸빵1번지 - 江南カラオケラウンジ・ハイパーパブリック予約",
+      "description": "江南、論峴、駅三エリアのカラオケラウンジ、ハイパーパブリック、シャツルーム情報を比較し、料金・場所・予約特典を確認できます。",
+      "shopTitleSuffix": " – ルンパン一番地",
+      "shopTitleTemplate": "{{shopName}} - {{district}} {{category}} 料金・予約 | 룸빵1번지",
+      "shopDescriptionTemplate": "룸빵1번지で{{region}}の{{shopName}} {{category}}の料金、場所、営業時間、予約相談情報を確認できます。"
     },
     "header": {
       "languageLabel": "言語",
@@ -864,7 +910,19 @@
         "広津区",
         "道峰区",
         "陽川区"
-      ]
+      ],
+      "priorityKeywords": [
+        "江南 カラオケラウンジ",
+        "江南 ハイパーパブリック",
+        "江南 シャツルーム",
+        "論峴 ラウンジ",
+        "駅三 ハイパーパブリック",
+        "韓国 ナイトライフ予約"
+      ],
+      "homeHeading": "江南カラオケラウンジ・ハイパーパブリック・シャツルーム予約ガイド",
+      "homeSummary": "룸빵1번지は江南、論峴、駅三の主要ナイトライフ店舗をエリアとカテゴリー別に整理し、料金、場所、予約相談情報を素早く比較できるようサポートします。",
+      "shopHeading": "{{district}} {{category}} {{shopName}} 料金・予約情報",
+      "shopSummary": "{{region}}にある{{shopName}}の料金、場所、営業時間、担当者情報を確認し、룸빵1번지で予約相談を進められます。"
     }
   }
 }

--- a/public/styles/components/utilities.css
+++ b/public/styles/components/utilities.css
@@ -21,3 +21,59 @@
 .seo-keywords {
   display: none;
 }
+
+.seo-overview {
+  padding-bottom: 0;
+}
+
+.seo-overview__container {
+  display: grid;
+  gap: 1rem;
+  padding: 1.5rem;
+  border: 1px solid rgba(212, 175, 55, 0.22);
+  border-radius: 1.5rem;
+  background: linear-gradient(135deg, rgba(28, 22, 18, 0.92), rgba(15, 15, 18, 0.86));
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.22);
+}
+
+.seo-overview__eyebrow {
+  margin: 0;
+  color: var(--color-gold, #d4af37);
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.seo-overview__title {
+  margin: 0;
+  color: var(--color-text-strong, #fff);
+  font-size: clamp(1.85rem, 4vw, 3.1rem);
+  line-height: 1.15;
+}
+
+.seo-overview__summary {
+  max-width: 760px;
+  margin: 0;
+  color: var(--color-text-muted, rgba(255, 255, 255, 0.72));
+  line-height: 1.75;
+}
+
+.seo-overview__keywords {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.seo-overview__keywords li {
+  padding: 0.42rem 0.72rem;
+  border: 1px solid rgba(212, 175, 55, 0.24);
+  border-radius: 999px;
+  color: var(--color-text, #f7f1df);
+  background: rgba(212, 175, 55, 0.08);
+  font-size: 0.88rem;
+  font-weight: 600;
+}

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -1,4 +1,21 @@
-<%- include('partials/head', { title: pageTitle, description: metaDescription, seoKeywords }) %>
+<%- include('partials/head', { title: pageTitle, description: metaDescription, seoKeywords, jsonLd }) %>
+  <% if (seoContent) { %>
+    <section class="section seo-overview" aria-labelledby="seo-overview-title">
+      <div class="container seo-overview__container">
+        <p class="seo-overview__eyebrow"><%= (t.meta && t.meta.siteName) || '룸빵1번지' %></p>
+        <h1 class="seo-overview__title" id="seo-overview-title"><%= seoContent.heading %></h1>
+        <p class="seo-overview__summary"><%= seoContent.summary %></p>
+        <% if (seoContent.keywordHighlights && seoContent.keywordHighlights.length) { %>
+          <ul class="seo-overview__keywords" aria-label="추천 검색 키워드">
+            <% seoContent.keywordHighlights.forEach(function(keyword) { %>
+              <li><%= keyword %></li>
+            <% }) %>
+          </ul>
+        <% } %>
+      </div>
+    </section>
+  <% } %>
+
   <section class="section" id="areas">
     <div class="container">
       <div class="section__header">
@@ -52,7 +69,4 @@
   <script id="region-district-data" type="application/json">
     <%- JSON.stringify(districtMap) %>
   </script>
-  <div class="seo-keywords" aria-hidden="true">
-    <%- seoKeywords.join(', ') %>
-  </div>
 <%- include('partials/footer') %>

--- a/views/partials/head.ejs
+++ b/views/partials/head.ejs
@@ -46,8 +46,13 @@
       .filter(Boolean);
     %>
     <% if (resolvedSeoKeywords.length) { %>
-      <meta name="keywords" content="<%= resolvedSeoKeywords.join(', ') %>" />
+      <meta name="keywords" content="<%= resolvedSeoKeywords.slice(0, 40).join(', ') %>" />
     <% } %>
+    <% const resolvedJsonLd =
+      typeof viewLocals.jsonLd === 'object' && viewLocals.jsonLd !== null
+        ? viewLocals.jsonLd
+        : null;
+    %>
     <meta property="og:type" content="website" />
     <meta property="og:title" content="<%= title || (t.meta && t.meta.defaultTitle) || 'Gangnam King' %>" />
     <meta
@@ -55,6 +60,12 @@
       content="<%= (typeof description === 'string' && description.length) ? description : ((t.meta && t.meta.description) || '') %>"
     />
     <meta property="og:site_name" content="<%= (t.meta && t.meta.siteName) || 'Gangnam King' %>" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="<%= title || (t.meta && t.meta.defaultTitle) || 'Gangnam King' %>" />
+    <meta
+      name="twitter:description"
+      content="<%= (typeof description === 'string' && description.length) ? description : ((t.meta && t.meta.description) || '') %>"
+    />
     <% const resolvedCanonicalUrl =
       typeof viewLocals.canonicalUrl === 'string' && viewLocals.canonicalUrl.trim()
         ? viewLocals.canonicalUrl
@@ -80,6 +91,9 @@
     <% } %>
     <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon-roompang.png" />
     <link rel="apple-touch-icon" href="/images/favicon-roompang.png" />
+    <% if (resolvedJsonLd) { %>
+      <script type="application/ld+json"><%- JSON.stringify(resolvedJsonLd) %></script>
+    <% } %>
     <link rel="stylesheet" href="/styles/main.css" />
     <% const rawExtraStyles =
       Object.prototype.hasOwnProperty.call(viewLocals, 'extraStyles')

--- a/views/shop.ejs
+++ b/views/shop.ejs
@@ -129,8 +129,26 @@
   seoKeywords,
   subheaderNavItems,
   areaFilterConfig: null,
-  extraStyles: extraMapStyles
+  extraStyles: extraMapStyles,
+  jsonLd
 }) %>
+  <% if (seoContent) { %>
+    <section class="section seo-overview seo-overview--detail" aria-labelledby="shop-seo-title">
+      <div class="container seo-overview__container">
+        <p class="seo-overview__eyebrow"><%= shop.region %> · <%= shop.district %> · <%= shop.category %></p>
+        <h1 class="seo-overview__title" id="shop-seo-title"><%= seoContent.heading %></h1>
+        <p class="seo-overview__summary"><%= seoContent.summary %></p>
+        <% if (seoContent.keywordHighlights && seoContent.keywordHighlights.length) { %>
+          <ul class="seo-overview__keywords" aria-label="상세 검색 키워드">
+            <% seoContent.keywordHighlights.forEach(function(keyword) { %>
+              <li><%= keyword %></li>
+            <% }) %>
+          </ul>
+        <% } %>
+      </div>
+    </section>
+  <% } %>
+
   <section class="section detail-section detail-hero">
     <div class="container">
       <div class="detail-section__grid detail-hero__grid">
@@ -148,7 +166,7 @@
           </div>
           <div class="detail-hero__info">
             <p class="detail-hero__meta"><%= shop.region %> · <%= shop.district %> · <%= shop.category %></p>
-            <h1><%= shop.name %></h1>
+            <h2><%= shop.name %></h2>
             <dl class="detail-hero__list">
               <div>
                 <dt><%= t.shop && t.shop.address ? t.shop.address : 'Address' %></dt>


### PR DESCRIPTION
### Motivation
- Improve on-page SEO by surfacing prioritized, localized keywords and human-friendly SEO copy on the home and shop pages. 
- Reduce keyword overuse while exposing a limited, relevant set of search terms for meta tags and visible keyword chips. 
- Provide structured data (JSON-LD) for Organization and LocalBusiness to help search engines index the site more reliably.

### Description
- Added reusable SEO utilities and builders in `controllers/shopController.js` (`normalizeKeywords`, `uniqueKeywords`, `pickKeywords`, `buildHomeSeoContent`, `buildShopSeoContent`, `buildOrganizationJsonLd`, `buildShopJsonLd`) and integrated them into `renderIndex` and `renderShopDetail` to pass `seoContent`, bounded `seoKeywords`, and `jsonLd` to views. 
- Updated `views/partials/head.ejs` to bound `meta[name=keywords]` (slice to first 40), add Twitter card meta, and emit `application/ld+json` when `jsonLd` is provided. 
- Added visible SEO overview sections and keyword chips to `views/index.ejs` and `views/shop.ejs`, moved the shop page main name from `h1` to `h2` to keep a single SEO heading, and wired the new SEO content into templates. 
- Extended `data/translations.json` for `ko/en/zh/ja` to include `meta` title/description templates and `seo` fields (`priorityKeywords`, `homeHeading`, `homeSummary`, `shopHeading`, `shopSummary`), and added styles for the SEO overview in `public/styles/components/utilities.css`.

### Testing
- Verified syntax of modified controller with `node -c controllers/shopController.js` which succeeded. 
- Validated modified translations JSON with `node -e "JSON.parse(require('fs').readFileSync('data/translations.json','utf8'))"` which succeeded. 
- Ran `git diff --check` and inspected diffs and committed the changes (commit message: `Optimize site SEO keywords`). 
- Performed a smoke run by launching the server (`PORT=3100 node app.js`) and fetching `/` and a shop detail URL with `curl`, confirming the presence of the SEO overview, keyword chips, and `application/ld+json` in the responses; these checks succeeded. 
- Attempted `npm test -- --runInBand` but it failed because `package.json` has no `test` script (expected).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4451917cd4832585b6c371219791ee)