### PR TITLE
Move SEO overview sections below main content

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -1,23 +1,4 @@
 <%- include('partials/head', { title: pageTitle, description: metaDescription, seoKeywords, jsonLd }) %>
-  <% if (seoContent) { %>
-    <section class="section seo-overview" aria-labelledby="seo-overview-title">
-      <div class="container">
-        <div class="seo-overview__container">
-          <p class="seo-overview__eyebrow"><%= (t.meta && t.meta.siteName) || '룸빵1번지' %></p>
-          <h1 class="seo-overview__title" id="seo-overview-title"><%= seoContent.heading %></h1>
-          <p class="seo-overview__summary"><%= seoContent.summary %></p>
-          <% if (seoContent.keywordHighlights && seoContent.keywordHighlights.length) { %>
-            <ul class="seo-overview__keywords" aria-label="추천 검색 키워드">
-              <% seoContent.keywordHighlights.forEach(function(keyword) { %>
-                <li><%= keyword %></li>
-              <% }) %>
-            </ul>
-          <% } %>
-        </div>
-      </div>
-    </section>
-  <% } %>
-
   <section class="section" id="areas">
     <div class="container">
       <div class="section__header">
@@ -67,6 +48,25 @@
       </div>
     </div>
   </section>
+
+  <% if (seoContent) { %>
+    <section class="section seo-overview" aria-labelledby="seo-overview-title">
+      <div class="container">
+        <div class="seo-overview__container">
+          <p class="seo-overview__eyebrow"><%= (t.meta && t.meta.siteName) || '룸빵1번지' %></p>
+          <h1 class="seo-overview__title" id="seo-overview-title"><%= seoContent.heading %></h1>
+          <p class="seo-overview__summary"><%= seoContent.summary %></p>
+          <% if (seoContent.keywordHighlights && seoContent.keywordHighlights.length) { %>
+            <ul class="seo-overview__keywords" aria-label="추천 검색 키워드">
+              <% seoContent.keywordHighlights.forEach(function(keyword) { %>
+                <li><%= keyword %></li>
+              <% }) %>
+            </ul>
+          <% } %>
+        </div>
+      </div>
+    </section>
+  <% } %>
 
   <script id="region-district-data" type="application/json">
     <%- JSON.stringify(districtMap) %>

--- a/views/shop.ejs
+++ b/views/shop.ejs
@@ -132,25 +132,6 @@
   extraStyles: extraMapStyles,
   jsonLd
 }) %>
-  <% if (seoContent) { %>
-    <section class="section seo-overview seo-overview--detail" aria-labelledby="shop-seo-title">
-      <div class="container">
-        <div class="seo-overview__container">
-          <p class="seo-overview__eyebrow"><%= shop.region %> · <%= shop.district %> · <%= shop.category %></p>
-          <h1 class="seo-overview__title" id="shop-seo-title"><%= seoContent.heading %></h1>
-          <p class="seo-overview__summary"><%= seoContent.summary %></p>
-          <% if (seoContent.keywordHighlights && seoContent.keywordHighlights.length) { %>
-            <ul class="seo-overview__keywords" aria-label="상세 검색 키워드">
-              <% seoContent.keywordHighlights.forEach(function(keyword) { %>
-                <li><%= keyword %></li>
-              <% }) %>
-            </ul>
-          <% } %>
-        </div>
-      </div>
-    </section>
-  <% } %>
-
   <section class="section detail-section detail-hero">
     <div class="container">
       <div class="detail-section__grid detail-hero__grid">
@@ -1116,6 +1097,25 @@
       </div>
     </section>
   </div>
+  <% if (seoContent) { %>
+    <section class="section seo-overview seo-overview--detail" aria-labelledby="shop-seo-title">
+      <div class="container">
+        <div class="seo-overview__container">
+          <p class="seo-overview__eyebrow"><%= shop.region %> · <%= shop.district %> · <%= shop.category %></p>
+          <h1 class="seo-overview__title" id="shop-seo-title"><%= seoContent.heading %></h1>
+          <p class="seo-overview__summary"><%= seoContent.summary %></p>
+          <% if (seoContent.keywordHighlights && seoContent.keywordHighlights.length) { %>
+            <ul class="seo-overview__keywords" aria-label="상세 검색 키워드">
+              <% seoContent.keywordHighlights.forEach(function(keyword) { %>
+                <li><%= keyword %></li>
+              <% }) %>
+            </ul>
+          <% } %>
+        </div>
+      </div>
+    </section>
+  <% } %>
+
 <%
   const mapScripts = [];
   if (typeof kakaoMapAppKey === 'string' && kakaoMapAppKey.trim()) {


### PR DESCRIPTION
### Motivation
- Reposition SEO overview blocks so they don't appear before the main page content on both the home and shop detail pages.

### Description
- Update `views/index.ejs` to remove the top `section.seo-overview` and reinsert it immediately after the main `section#areas` block.
- Update `views/shop.ejs` to move `section.seo-overview seo-overview--detail` from the top of the detail template to immediately after the `detail-location` block.
- The changes only relocate the existing markup and do not alter the SEO text or keyword rendering logic.

### Testing
- Compiled both templates using `ejs.compile(...)` in a Node one-liner and both files compiled successfully.
- Ran `git diff --check` which reported no whitespace or diff errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4507fed2b08325967b538f2ea9290b)