### PR TITLE
Limit displayed entry workers to fifteen

### DIFF
--- a/controllers/entry/entryController.js
+++ b/controllers/entry/entryController.js
@@ -231,6 +231,7 @@ async function fetchAllStoreEntries() {
 }
 
 const ENTRY_ROW_SIZE = 5;
+const ENTRY_WORKER_DISPLAY_LIMIT = 15;
 
 async function fetchStoreMetadata(storeNo) {
   const stores = readEntryStores();
@@ -268,7 +269,7 @@ function buildWorkerRows(entries) {
     .map((entry) => (typeof entry.workerName === 'string' ? entry.workerName.trim() : ''))
     .filter(Boolean);
 
-  return chunkArray(workerNames, ENTRY_ROW_SIZE);
+  return chunkArray(workerNames.slice(0, ENTRY_WORKER_DISPLAY_LIMIT), ENTRY_ROW_SIZE);
 }
 
 function buildTopEntriesPayload(topEntries) {
@@ -555,7 +556,8 @@ function buildStoreEntryLines(store, entries, top5) {
   if (entries.length) {
     lines.push({ text: '엔트리 목록', fontSize: 30, fontWeight: '700', gapBefore: 28 });
 
-    const entryRows = chunkArray(entries, ENTRY_ROW_SIZE);
+    const displayEntries = entries.slice(0, ENTRY_WORKER_DISPLAY_LIMIT);
+    const entryRows = chunkArray(displayEntries, ENTRY_ROW_SIZE);
     entryRows.forEach((row, index) => {
       const chunkText = row
         .map((entry) => entry.workerName ?? '')
@@ -617,7 +619,8 @@ function buildAllStoreEntryLines(storeDataList) {
     });
 
     if (data.entries.length) {
-      const entryRows = chunkArray(data.entries, ENTRY_ROW_SIZE);
+      const displayEntries = data.entries.slice(0, ENTRY_WORKER_DISPLAY_LIMIT);
+      const entryRows = chunkArray(displayEntries, ENTRY_ROW_SIZE);
       entryRows.forEach((row, index) => {
         lines.push({
           text: row.map((entry) => entry.workerName ?? '').join(' '),


### PR DESCRIPTION
### Motivation
- Users expect the UI to show up to 15 worker names while the system should still fetch and count the full entry dataset so the reported attendance remains accurate.
- The previous behavior returned only a small subset in the payloads/visuals, causing confusion about total attendance numbers.

### Description
- Add `ENTRY_WORKER_DISPLAY_LIMIT = 15` and use it to cap displayed worker names while keeping the full `entries` array intact.
- Limit `buildWorkerRows` to the first 15 worker names (`workerNames.slice(0, ENTRY_WORKER_DISPLAY_LIMIT)`) used for JSON/page payloads so UI rows show at most 15 names in rows of `ENTRY_ROW_SIZE`.
- For SVG generation, slice `entries` to the first 15 in `buildStoreEntryLines` and `buildAllStoreEntryLines` before creating entry rows so generated images also show up to 15 names while preserving layout logic.
- Preserve total attendance counts by continuing to compute `totalWorkers` and aggregated totals from the full `entries.length` values.

### Testing
- Ran `git diff --check` to validate no whitespace/merge errors and it succeeded.
- Ran `node --check controllers/entry/entryController.js` to ensure the modified file is syntactically valid and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a450dc72f7c8325820003f18700c968)