### PR TITLE
Show all entry workers

### DIFF
--- a/controllers/entry/entryController.js
+++ b/controllers/entry/entryController.js
@@ -231,7 +231,6 @@ async function fetchAllStoreEntries() {
 }
 
 const ENTRY_ROW_SIZE = 5;
-const ENTRY_WORKER_DISPLAY_LIMIT = 15;
 
 async function fetchStoreMetadata(storeNo) {
   const stores = readEntryStores();
@@ -269,7 +268,7 @@ function buildWorkerRows(entries) {
     .map((entry) => (typeof entry.workerName === 'string' ? entry.workerName.trim() : ''))
     .filter(Boolean);
 
-  return chunkArray(workerNames.slice(0, ENTRY_WORKER_DISPLAY_LIMIT), ENTRY_ROW_SIZE);
+  return chunkArray(workerNames, ENTRY_ROW_SIZE);
 }
 
 function buildTopEntriesPayload(topEntries) {
@@ -556,8 +555,7 @@ function buildStoreEntryLines(store, entries, top5) {
   if (entries.length) {
     lines.push({ text: '엔트리 목록', fontSize: 30, fontWeight: '700', gapBefore: 28 });
 
-    const displayEntries = entries.slice(0, ENTRY_WORKER_DISPLAY_LIMIT);
-    const entryRows = chunkArray(displayEntries, ENTRY_ROW_SIZE);
+    const entryRows = chunkArray(entries, ENTRY_ROW_SIZE);
     entryRows.forEach((row, index) => {
       const chunkText = row
         .map((entry) => entry.workerName ?? '')
@@ -619,8 +617,7 @@ function buildAllStoreEntryLines(storeDataList) {
     });
 
     if (data.entries.length) {
-      const displayEntries = data.entries.slice(0, ENTRY_WORKER_DISPLAY_LIMIT);
-      const entryRows = chunkArray(displayEntries, ENTRY_ROW_SIZE);
+      const entryRows = chunkArray(data.entries, ENTRY_ROW_SIZE);
       entryRows.forEach((row, index) => {
         lines.push({
           text: row.map((entry) => entry.workerName ?? '').join(' '),

--- a/controllers/shopController.js
+++ b/controllers/shopController.js
@@ -69,9 +69,6 @@ function buildEntryTopList(entries, limit = 5) {
 }
 
 const ENTRY_ROW_SIZE = 5;
-const ENTRY_WORKER_PREVIEW_LIMIT = 15;
-const ENTRY_MORE_LINK = 'https://nightmens.com/play/live';
-
 function buildEntrySummary(entries, workerNames) {
   const normalizedWorkerNames = Array.isArray(workerNames)
     ? workerNames
@@ -79,17 +76,15 @@ function buildEntrySummary(entries, workerNames) {
         .filter(Boolean)
     : [];
 
-  const previewWorkerNames = normalizedWorkerNames.slice(0, ENTRY_WORKER_PREVIEW_LIMIT);
-  const workerRows = chunkArray(previewWorkerNames, ENTRY_ROW_SIZE);
-  const hiddenWorkerCount = Math.max(normalizedWorkerNames.length - previewWorkerNames.length, 0);
+  const workerRows = chunkArray(normalizedWorkerNames, ENTRY_ROW_SIZE);
 
   return {
     enabled: false,
     totalCount: Array.isArray(entries) ? entries.length : 0,
     workerRows,
     hasWorkerRows: workerRows.some((row) => Array.isArray(row) && row.length),
-    hiddenWorkerCount,
-    moreLink: hiddenWorkerCount > 0 ? ENTRY_MORE_LINK : '',
+    hiddenWorkerCount: 0,
+    moreLink: '',
     topEntries: buildEntryTopList(entries),
   };
 }


### PR DESCRIPTION
### Motivation
- The entry worker list was capped and paginated for preview, causing only a subset (e.g. 10/15) of worker names to be shown instead of the full set from the database.
- The goal is to surface every worker name in the store entry section and include them in API/image payloads so no workers are silently omitted.

### Description
- Removed the preview/display limits and `slice` calls so worker name arrays are passed intact into row chunking in `controllers/shopController.js` and `controllers/entry/entryController.js`.
- Replaced use of `ENTRY_WORKER_PREVIEW_LIMIT`/`ENTRY_WORKER_DISPLAY_LIMIT` with direct chunking via `chunkArray(..., ENTRY_ROW_SIZE)` so all normalized names are rendered in 5-per-row groups.
- Removed the `ENTRY_MORE_LINK`/hidden-count logic in the shop summary payload; the summary now returns `hiddenWorkerCount: 0` and `moreLink: ''` when prefilled.
- Updated store entry payloads and image/lines builders to use the full `entries` list when building rows and output lines so generated payloads and images include every worker.

### Testing
- Ran `node -c controllers/shopController.js` and it succeeded.
- Ran `node -c controllers/entry/entryController.js` and it succeeded.
- Ran `node -c public/scripts/pages/shop-detail.js` and it succeeded.
- Ran `git diff --check` to verify no whitespace/patch errors and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4519e510f883258251e13ea1eb7a57)