### PR TITLE
Add Midnight Mens community link

### DIFF
--- a/public/styles/components/utilities.css
+++ b/public/styles/components/utilities.css
@@ -77,3 +77,17 @@
   font-size: 0.88rem;
   font-weight: 600;
 }
+
+.seo-overview__community-link {
+  display: inline-flex;
+  width: fit-content;
+  color: var(--color-gold, #d4af37);
+  font-weight: 700;
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+}
+
+.seo-overview__community-link:hover,
+.seo-overview__community-link:focus-visible {
+  color: var(--color-text-strong, #fff);
+}

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -63,6 +63,7 @@
               <% }) %>
             </ul>
           <% } %>
+          <a class="seo-overview__community-link" href="https://nightmens.com/community" target="_blank" rel="noopener noreferrer">유흥 커뮤니티 소통 사이트 미드나잇맨즈</a>
         </div>
       </div>
     </section>


### PR DESCRIPTION
### Motivation
- Add an external community link for "유흥 커뮤니티 소통 사이트 미드나잇맨즈" under the `seo-overview__container` so users can easily access the Midnight Mens community from the homepage.

### Description
- Inserted an anchor element in `views/index.ejs` inside the SEO overview block and added `.seo-overview__community-link` styling to `public/styles/components/utilities.css` including hover and focus states.

### Testing
- Verified `views/index.ejs` compiles with `node -e "require('ejs').compile(require('fs').readFileSync('views/index.ejs','utf8'))"`, ran `git diff --check` with no issues, started the app via `PORT=3000 npm start`, and confirmed the link appears in the homepage HTML using `curl -s http://localhost:3000/ | rg -n "미드나잇맨즈|seo-overview__community-link"`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a452b00f218832599d54c926fcc54c5)