### PR TITLE
Separate Midnightmens promo banner into its own container

### DIFF
--- a/public/styles/components/utilities.css
+++ b/public/styles/components/utilities.css
@@ -92,6 +92,17 @@
   color: var(--color-text-strong, #fff);
 }
 
+.seo-overview__promo-container {
+  display: flex;
+  justify-content: center;
+  margin-top: 1rem;
+  padding: 1rem;
+  border: 1px solid rgba(212, 175, 55, 0.18);
+  border-radius: 1.5rem;
+  background: linear-gradient(135deg, rgba(10, 10, 14, 0.88), rgba(31, 23, 18, 0.76));
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.18);
+}
+
 .seo-overview__promo {
   display: block;
   overflow: hidden;

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -64,6 +64,8 @@
             </ul>
           <% } %>
           <a class="seo-overview__community-link" href="https://nightmens.com/community" target="_blank" rel="noopener noreferrer">유흥 커뮤니티 소통 사이트 미드나잇맨즈</a>
+        </div>
+        <div class="seo-overview__promo-container" aria-label="미드나잇맨즈 홍보 배너">
           <a
             class="seo-overview__promo"
             href="https://nightmens.com/community"

--- a/views/shop.ejs
+++ b/views/shop.ejs
@@ -1135,6 +1135,8 @@
               <% }) %>
             </ul>
           <% } %>
+        </div>
+        <div class="seo-overview__promo-container" aria-label="미드나잇맨즈 홍보 배너">
           <a
             class="seo-overview__promo"
             href="https://nightmens.com/community"


### PR DESCRIPTION
### Motivation
- Visually and semantically separate the Midnightmens promo banner from the SEO content card so the promo can be styled and positioned independently.
- Allow the promo banner to appear as a distinct section while preserving its existing link behavior.

### Description
- Move the promo anchor and image out of the `seo-overview__container` into a new sibling element `seo-overview__promo-container` in `views/index.ejs` and `views/shop.ejs`.
- Add styling for the new `seo-overview__promo-container` in `public/styles/components/utilities.css` to provide padding, border, background and shadow for visual separation.
- Preserve existing classes and attributes on the anchor and image (`seo-overview__promo`, `seo-overview__promo-image`) so link targets and image behavior remain unchanged.

### Testing
- Ran `node --check app.js && node --check routes/index.js && node --check middleware/language.js` and it completed without errors.
- Launched the server with `PORT=3000 node app.js` and verified the homepage HTML contains `seo-overview__promo-container` and the banner `midnightmens.png` via `curl`.
- Ran `git diff --check` to ensure there are no whitespace or diff issues and it returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4535641d1083258db47269b9204376)