### PR TITLE
Add Midnightmens promo description and stack copy above banner image

### DIFF
--- a/public/styles/components/utilities.css
+++ b/public/styles/components/utilities.css
@@ -92,9 +92,27 @@
   color: var(--color-text-strong, #fff);
 }
 
+.seo-overview__promo-copy {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.6rem;
+  max-width: 760px;
+  text-align: center;
+}
+
+.seo-overview__community-description {
+  margin: 0;
+  color: var(--color-text-muted, #d9cfb4);
+  font-size: 0.98rem;
+  line-height: 1.75;
+}
+
 .seo-overview__promo-container {
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
   margin-top: 1rem;
   padding: 1rem;
   border: 1px solid rgba(212, 175, 55, 0.18);

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -63,9 +63,14 @@
               <% }) %>
             </ul>
           <% } %>
-          <a class="seo-overview__community-link" href="https://nightmens.com/community" target="_blank" rel="noopener noreferrer">유흥 커뮤니티 소통 사이트 미드나잇맨즈</a>
         </div>
-        <div class="seo-overview__promo-container" aria-label="미드나잇맨즈 홍보 배너">
+        <div class="seo-overview__promo-container" aria-label="미드나잇맨즈 유흥 커뮤니티 홍보 영역">
+          <div class="seo-overview__promo-copy">
+            <a class="seo-overview__community-link" href="https://nightmens.com/community" target="_blank" rel="noopener noreferrer">유흥 커뮤니티 소통 사이트 미드나잇맨즈</a>
+            <p class="seo-overview__community-description">
+              미드나잇맨즈는 유흥 관련 소통을 위한 커뮤니티 사이트로, 가게별 현장 상황과 여러 업체의 금액 비교, 실제 후기를 확인할 수 있는 콘텐츠를 제공합니다. 유흥 커뮤니티를 메인 유입 키워드로 삼아 강남하퍼, 강남 달토, 달리는토끼, 유앤미, 쩜오 등 주요 검색 키워드 정보를 함께 다룹니다.
+            </p>
+          </div>
           <a
             class="seo-overview__promo"
             href="https://nightmens.com/community"

--- a/views/shop.ejs
+++ b/views/shop.ejs
@@ -1136,7 +1136,13 @@
             </ul>
           <% } %>
         </div>
-        <div class="seo-overview__promo-container" aria-label="미드나잇맨즈 홍보 배너">
+        <div class="seo-overview__promo-container" aria-label="미드나잇맨즈 유흥 커뮤니티 홍보 영역">
+          <div class="seo-overview__promo-copy">
+            <a class="seo-overview__community-link" href="https://nightmens.com/community" target="_blank" rel="noopener noreferrer">유흥 커뮤니티 소통 사이트 미드나잇맨즈</a>
+            <p class="seo-overview__community-description">
+              미드나잇맨즈는 유흥 관련 소통을 위한 커뮤니티 사이트로, 가게별 현장 상황과 여러 업체의 금액 비교, 실제 후기를 확인할 수 있는 콘텐츠를 제공합니다. 유흥 커뮤니티를 메인 유입 키워드로 삼아 강남하퍼, 강남 달토, 달리는토끼, 유앤미, 쩜오 등 주요 검색 키워드 정보를 함께 다룹니다.
+            </p>
+          </div>
           <a
             class="seo-overview__promo"
             href="https://nightmens.com/community"


### PR DESCRIPTION
### Motivation
- Surface the Midnightmens community link and explanatory copy above the promo banner to provide context and improve SEO for targeted keywords like `유흥 커뮤니티`, `강남하퍼`, `강남 달토`, `달리는토끼`, `유앤미`, and `쩜오`.

### Description
- Move the Midnightmens community link into the promo banner area and add a short descriptive paragraph above the promo image in `views/index.ejs` and `views/shop.ejs` with appropriate copy and keyword mentions.
- Wrap the link and description in a new `.seo-overview__promo-copy` block and update the promo container `aria-label` to indicate the community promo region.
- Add a `.seo-overview__community-description` style and update `.seo-overview__promo-container` layout to stack and center content via `public/styles/components/utilities.css`.
- Keep the existing promo image and link destination (`https://nightmens.com/community`) unchanged and preserve accessibility attributes like `aria-label` and `alt` on the image.

### Testing
- Ran `git diff --check` which completed without issues (success).
- Launched the app with `PORT=3100 node app.js` and fetched the home page with `curl -fsS http://127.0.0.1:3100/` to verify the new promo copy and keywords render on the page (success).
- Checked for a headless browser/Playwright binary as an automated rendering tool and it was not available in the environment, so visual snapshot testing was not executed (not available).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45372f46e08325a23c2724c57548d7)