### PR TITLE
Limit entry roster display to 15 and add “more” link

### DIFF
--- a/controllers/entry/entryController.js
+++ b/controllers/entry/entryController.js
@@ -6,6 +6,9 @@ const { getShops } = require('../../services/dataStore');
 
 const COMMUNITY_CHAT_LINK = 'https://open.kakao.com/o/gALpMlRg';
 const COMMUNITY_CONTACT_TEXT = '강남 하퍼 010-5733-8710';
+const ENTRY_DISPLAY_LIMIT = 15;
+const MORE_ENTRIES_URL = 'https://nightmens.com/play/live';
+
 const ENTRY_PAGE_TEXT = {
   loading: '출근부 정보를 불러오는 중입니다...',
   error: '출근부 정보를 가져오지 못했습니다. 잠시 후 다시 시도해주세요.',
@@ -263,10 +266,11 @@ function chunkArray(items, size) {
   return chunks;
 }
 
-function buildWorkerRows(entries) {
+function buildWorkerRows(entries, limit = ENTRY_DISPLAY_LIMIT) {
   const workerNames = entries
     .map((entry) => (typeof entry.workerName === 'string' ? entry.workerName.trim() : ''))
-    .filter(Boolean);
+    .filter(Boolean)
+    .slice(0, limit);
 
   return chunkArray(workerNames, ENTRY_ROW_SIZE);
 }
@@ -283,6 +287,9 @@ function buildStoreEntryPayload(store, entries, top5) {
     storeNo: store.storeNo,
     storeName: store.storeName,
     totalWorkers: entries.length,
+    visibleWorkerLimit: ENTRY_DISPLAY_LIMIT,
+    remainingWorkers: Math.max(0, entries.length - ENTRY_DISPLAY_LIMIT),
+    moreEntriesUrl: MORE_ENTRIES_URL,
     workerRows: buildWorkerRows(entries),
     topEntries: buildTopEntriesPayload(top5),
   };
@@ -555,7 +562,9 @@ function buildStoreEntryLines(store, entries, top5) {
   if (entries.length) {
     lines.push({ text: '엔트리 목록', fontSize: 30, fontWeight: '700', gapBefore: 28 });
 
-    const entryRows = chunkArray(entries, ENTRY_ROW_SIZE);
+    const visibleEntries = entries.slice(0, ENTRY_DISPLAY_LIMIT);
+    const remainingCount = Math.max(0, entries.length - ENTRY_DISPLAY_LIMIT);
+    const entryRows = chunkArray(visibleEntries, ENTRY_ROW_SIZE);
     entryRows.forEach((row, index) => {
       const chunkText = row
         .map((entry) => entry.workerName ?? '')
@@ -568,6 +577,16 @@ function buildStoreEntryLines(store, entries, top5) {
         gapBefore: index === 0 ? 12 : 8,
       });
     });
+
+    if (remainingCount > 0) {
+      lines.push({
+        text: `출근자 ${remainingCount}명 더 보기... ${MORE_ENTRIES_URL}`,
+        fontSize: 24,
+        fontWeight: '700',
+        lineHeight: 34,
+        gapBefore: 14,
+      });
+    }
 
     if (top5.length) {
       lines.push({ text: '오늘의 인기 멤버 TOP 5', fontSize: 30, fontWeight: '700', gapBefore: 32 });
@@ -617,7 +636,9 @@ function buildAllStoreEntryLines(storeDataList) {
     });
 
     if (data.entries.length) {
-      const entryRows = chunkArray(data.entries, ENTRY_ROW_SIZE);
+      const visibleEntries = data.entries.slice(0, ENTRY_DISPLAY_LIMIT);
+      const remainingCount = Math.max(0, data.entries.length - ENTRY_DISPLAY_LIMIT);
+      const entryRows = chunkArray(visibleEntries, ENTRY_ROW_SIZE);
       entryRows.forEach((row, index) => {
         lines.push({
           text: row.map((entry) => entry.workerName ?? '').join(' '),
@@ -626,6 +647,16 @@ function buildAllStoreEntryLines(storeDataList) {
           gapBefore: index === 0 ? 12 : 8,
         });
       });
+
+      if (remainingCount > 0) {
+        lines.push({
+          text: `출근자 ${remainingCount}명 더 보기... ${MORE_ENTRIES_URL}`,
+          fontSize: 24,
+          fontWeight: '700',
+          lineHeight: 34,
+          gapBefore: 14,
+        });
+      }
 
       if (data.top5.length) {
         lines.push({

--- a/public/scripts/pages/entry-map.js
+++ b/public/scripts/pages/entry-map.js
@@ -72,7 +72,7 @@
     setVisibility(storesHost, true);
   }
 
-  function createWorkerRows(rows) {
+  function createWorkerRows(rows, remainingCount, moreUrl) {
     const container = document.createElement('div');
     container.className = 'entry-rows';
 
@@ -109,6 +109,17 @@
       empty.className = 'entry-empty';
       empty.textContent = workerEmptyText;
       container.appendChild(empty);
+    }
+
+    const normalizedRemaining = Number.isFinite(remainingCount) ? remainingCount : 0;
+    if (normalizedRemaining > 0 && typeof moreUrl === 'string' && moreUrl.trim()) {
+      const moreLink = document.createElement('a');
+      moreLink.className = 'entry-more-link';
+      moreLink.href = moreUrl.trim();
+      moreLink.target = '_blank';
+      moreLink.rel = 'noopener noreferrer';
+      moreLink.textContent = `출근자 ${numberFormatter.format(normalizedRemaining)}명 더 보기...`;
+      container.appendChild(moreLink);
     }
 
     return container;
@@ -173,7 +184,7 @@
     const workersTitle = document.createElement('h3');
     workersTitle.textContent = '출근부 목록';
     workersSection.appendChild(workersTitle);
-    workersSection.appendChild(createWorkerRows(store.workerRows));
+    workersSection.appendChild(createWorkerRows(store.workerRows, store.remainingWorkers, store.moreEntriesUrl));
 
     const topSection = document.createElement('div');
     topSection.className = 'top-section';

--- a/public/styles/entry-map.css
+++ b/public/styles/entry-map.css
@@ -180,6 +180,27 @@ body {
   color: var(--entry-muted);
 }
 
+.entry-more-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  align-self: flex-start;
+  margin-top: 10px;
+  padding: 9px 14px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--entry-accent), #7c3aed);
+  color: #fff;
+  font-weight: 700;
+  text-decoration: none;
+  box-shadow: 0 8px 18px rgba(75, 107, 251, 0.24);
+}
+
+.entry-more-link:hover,
+.entry-more-link:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 22px rgba(75, 107, 251, 0.3);
+}
+
 .top-list {
   list-style: none;
   padding: 0;


### PR DESCRIPTION
### Motivation
- Reduce crowding in the entry (출근부) UI and generated images by showing only the first 15 workers per store and provide a clear action for overflow entries.

### Description
- Add `ENTRY_DISPLAY_LIMIT = 15` and `MORE_ENTRIES_URL = 'https://nightmens.com/play/live'` constants and include `visibleWorkerLimit`, `remainingWorkers`, and `moreEntriesUrl` in the entry payload. (changes in `controllers/entry/entryController.js`)
- Trim worker lists sent to the client and used for SVG rendering to the first 15 entries and append a `출근자 n명 더 보기...` line in generated SVGs when there are additional workers. (changes in `controllers/entry/entryController.js`)
- Render a styled link `출근자 n명 더 보기...` in the frontend that opens `https://nightmens.com/play/live` in a new tab when more than 15 workers exist. (changes in `public/scripts/pages/entry-map.js`)
- Add CSS for the new `entry-more-link` button to `public/styles/entry-map.css`.

### Testing
- Ran `node --check controllers/entry/entryController.js` and it succeeded. 
- Ran `node --check public/scripts/pages/entry-map.js` and it succeeded. 
- Ran `git diff --check` and there were no whitespace/errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a453b5cf4148325805179fd4e6d7e91)