### PR TITLE
Show more entries link on shop detail

### DIFF
--- a/controllers/shopController.js
+++ b/controllers/shopController.js
@@ -69,22 +69,28 @@ function buildEntryTopList(entries, limit = 5) {
 }
 
 const ENTRY_ROW_SIZE = 5;
-function buildEntrySummary(entries, workerNames) {
+const ENTRY_DISPLAY_LIMIT = 15;
+const MORE_ENTRIES_URL = 'https://nightmens.com/play/live';
+
+function buildEntrySummary(entries, workerNames, limit = ENTRY_DISPLAY_LIMIT) {
   const normalizedWorkerNames = Array.isArray(workerNames)
     ? workerNames
         .map((name) => (typeof name === 'string' ? name.trim() : ''))
         .filter(Boolean)
     : [];
 
-  const workerRows = chunkArray(normalizedWorkerNames, ENTRY_ROW_SIZE);
+  const visibleWorkerLimit = Math.max(0, Number(limit) || 0);
+  const visibleWorkerNames = normalizedWorkerNames.slice(0, visibleWorkerLimit);
+  const workerRows = chunkArray(visibleWorkerNames, ENTRY_ROW_SIZE);
+  const hiddenWorkerCount = Math.max(0, normalizedWorkerNames.length - visibleWorkerNames.length);
 
   return {
     enabled: false,
     totalCount: Array.isArray(entries) ? entries.length : 0,
     workerRows,
     hasWorkerRows: workerRows.some((row) => Array.isArray(row) && row.length),
-    hiddenWorkerCount: 0,
-    moreLink: '',
+    hiddenWorkerCount,
+    moreLink: hiddenWorkerCount > 0 ? MORE_ENTRIES_URL : '',
     topEntries: buildEntryTopList(entries),
   };
 }


### PR DESCRIPTION
### Motivation
- Ensure the shop detail 출근부 section shows a “더 보기” CTA when there are more than a limited number of worker names instead of always hiding the link.

### Description
- Add `ENTRY_DISPLAY_LIMIT = 15` and `MORE_ENTRIES_URL` constants and update `buildEntrySummary` to accept a `limit` parameter in `controllers/shopController.js`.
- Limit visible worker names to `ENTRY_DISPLAY_LIMIT`, chunk them into rows using `ENTRY_ROW_SIZE`, and compute `hiddenWorkerCount` when more names exist.
- Populate `moreLink` with `MORE_ENTRIES_URL` when `hiddenWorkerCount > 0` and include the new fields in the returned summary payload.
- Change is confined to `controllers/shopController.js` and reuses existing view/client logic that displays the more-link when these fields are present.

### Testing
- `node --check controllers/shopController.js` — passed.
- `node --check public/scripts/pages/shop-detail.js` — passed.
- `git diff --check` — no issues found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45441f2fd48325bec19768e374d14b)