### PR TITLE
Align room map hero with entry-map styling

### DIFF
--- a/public/styles/room-map.css
+++ b/public/styles/room-map.css
@@ -14,24 +14,24 @@ body {
   color: var(--room-text);
 }
 
-.room-map-hero {
-  background: radial-gradient(circle at top, rgba(75, 107, 251, 0.2), rgba(75, 107, 251, 0.05));
-  border-bottom: 1px solid var(--room-border);
+.entry-map-hero {
+  background: radial-gradient(circle at top, rgba(75, 107, 251, 0.3), rgba(75, 107, 251, 0.05));
+  border-bottom: 1px solid #e4e5f0;
 }
 
-.room-map-hero__content {
+.entry-map-hero__content {
   max-width: 960px;
   margin: 0 auto;
   padding: 24px 16px;
 }
 
-.room-map-hero__lead {
+.entry-map-hero__lead {
   margin: 0 0 6px;
   font-weight: 600;
-  color: var(--room-muted);
+  color: #6b6f80;
 }
 
-.room-map-hero__link {
+.entry-map-hero__link {
   color: var(--room-accent);
   font-weight: 700;
   text-decoration: none;

--- a/views/room-map.ejs
+++ b/views/room-map.ejs
@@ -14,7 +14,7 @@
     <%- contentProtectionMarkup %>
   </head>
   <body>
-    <header class="room-map-hero">
+    <header class="entry-map-hero">
       <div class="entry-map-hero__content">
         <p class="entry-map-hero__lead">사이트이동 구글검색 "미드나잇맨즈"</p>
         <a class="entry-map-hero__link" href="https://www.google.com/search?q=미드나잇맨즈" target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
### Motivation
- Ensure the room map page header uses the same markup and visual styling as the entry pages for consistent UI appearance.

### Description
- Updated the header in `views/room-map.ejs` from `class="room-map-hero"` to `class="entry-map-hero"` and renamed the related selectors in `public/styles/room-map.css` to `.entry-map-hero`, adjusting the background, border, and lead text color to match the entry styling.

### Testing
- Ran `node --check app.js` and `git diff --check`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4546d6c29083258fd1b5a6b4fa96bf)