### PR TITLE
Limit shop entry worker previews to 15 and correct more-link/count behavior

### DIFF
--- a/public/scripts/pages/shop-detail.js
+++ b/public/scripts/pages/shop-detail.js
@@ -132,6 +132,8 @@
       const errorText = section.dataset.entryErrorText || '';
       const scoreLabel = section.dataset.entryTopScoreLabel || '';
       const locale = section.dataset.entryLocale || 'ko';
+      const visibleWorkerLimit = Math.max(0, Number(section.dataset.entryVisibleLimit) || 15);
+      const workerRowSize = 5;
       const workerEmptyDefault = workerEmpty
         ? workerEmpty.dataset.entryEmptyDefault || workerEmpty.textContent || ''
         : '';
@@ -158,6 +160,41 @@
           topEmpty.textContent = message || '';
           topEmpty.hidden = !message;
         }
+      }
+
+      function getVisibleWorkerSummary(summary) {
+        const names = [];
+        const rows = summary && Array.isArray(summary.workerRows) ? summary.workerRows : [];
+
+        rows.forEach((row) => {
+          if (!Array.isArray(row)) {
+            return;
+          }
+
+          row.forEach((name) => {
+            if (typeof name === 'string' && name.trim()) {
+              names.push(name.trim());
+            }
+          });
+        });
+
+        const visibleNames = names.slice(0, visibleWorkerLimit);
+        const visibleRows = [];
+
+        for (let index = 0; index < visibleNames.length; index += workerRowSize) {
+          visibleRows.push(visibleNames.slice(index, index + workerRowSize));
+        }
+
+        const hiddenFromRows = Math.max(0, names.length - visibleNames.length);
+        const hiddenFromSummary = Number(summary && summary.hiddenWorkerCount);
+
+        return {
+          rows: visibleRows,
+          hiddenWorkerCount: Math.max(
+            Number.isFinite(hiddenFromSummary) ? hiddenFromSummary : 0,
+            hiddenFromRows
+          ),
+        };
       }
 
       function renderWorkerRows(rows) {
@@ -213,7 +250,10 @@
         }
 
         const hiddenCount = Number(summary && summary.hiddenWorkerCount);
-        const href = summary && typeof summary.moreLink === 'string' ? summary.moreLink.trim() : '';
+        const summaryHref = summary && typeof summary.moreLink === 'string'
+          ? summary.moreLink.trim()
+          : '';
+        const href = summaryHref || moreLink.getAttribute('href') || '';
 
         if (!Number.isFinite(hiddenCount) || hiddenCount <= 0 || !href) {
           moreLink.hidden = true;
@@ -314,7 +354,8 @@
           );
         }
 
-        const hasWorkers = renderWorkerRows(summary.workerRows);
+        const visibleWorkerSummary = getVisibleWorkerSummary(summary);
+        const hasWorkers = renderWorkerRows(visibleWorkerSummary.rows);
         if (workerEmpty) {
           workerEmpty.hidden = hasWorkers;
           if (!hasWorkers) {
@@ -322,7 +363,10 @@
           }
         }
 
-        renderMoreLink(summary);
+        renderMoreLink({
+          ...summary,
+          hiddenWorkerCount: visibleWorkerSummary.hiddenWorkerCount,
+        });
 
         const hasTopEntries = renderTopEntries(summary.topEntries);
         if (topEmpty) {

--- a/views/shop.ejs
+++ b/views/shop.ejs
@@ -73,9 +73,29 @@
   const showEntrySection = true;
   //const showEntrySection = Boolean(entryOverview.enabled);
   const entrySnapshot = showEntrySection ? entryOverview : null;
-  const entrySnapshotWorkers = entrySnapshot && Array.isArray(entrySnapshot.workerRows)
+  const entryWorkerDisplayLimit = 15;
+  const entryWorkerRowSize = 5;
+  const entrySnapshotWorkerNames = entrySnapshot && Array.isArray(entrySnapshot.workerRows)
     ? entrySnapshot.workerRows
+        .flatMap(function(row) { return Array.isArray(row) ? row : []; })
+        .map(function(name) { return typeof name === 'string' ? name.trim() : ''; })
+        .filter(Boolean)
     : [];
+  const entryVisibleWorkerNames = entrySnapshotWorkerNames.slice(0, entryWorkerDisplayLimit);
+  const entrySnapshotWorkers = [];
+  for (let index = 0; index < entryVisibleWorkerNames.length; index += entryWorkerRowSize) {
+    entrySnapshotWorkers.push(entryVisibleWorkerNames.slice(index, index + entryWorkerRowSize));
+  }
+  const entryExtraHiddenWorkerCount = Math.max(
+    0,
+    entrySnapshotWorkerNames.length - entryVisibleWorkerNames.length
+  );
+  const entryHiddenWorkerCount = entrySnapshot
+    ? Math.max(Number(entrySnapshot.hiddenWorkerCount) || 0, entryExtraHiddenWorkerCount)
+    : 0;
+  const entryMoreLink = entrySnapshot && typeof entrySnapshot.moreLink === 'string' && entrySnapshot.moreLink.trim()
+    ? entrySnapshot.moreLink.trim()
+    : 'https://nightmens.com/play/live';
   const entrySnapshotTop = entrySnapshot && Array.isArray(entrySnapshot.topEntries)
     ? entrySnapshot.topEntries
     : [];
@@ -901,8 +921,8 @@
             totalCount: entrySnapshot ? entrySnapshot.totalCount : null,
             workerRows: entrySnapshotWorkers,
             topEntries: entrySnapshotTop,
-            hiddenWorkerCount: entrySnapshot ? entrySnapshot.hiddenWorkerCount : 0,
-            moreLink: entrySnapshot ? entrySnapshot.moreLink : '',
+            hiddenWorkerCount: entryHiddenWorkerCount,
+            moreLink: entryMoreLink,
           }
         : null; %>
     <section
@@ -913,6 +933,7 @@
       data-entry-locale="<%= entryLocale %>"
       data-entry-top-score-label="<%= entriesTopListScoreLabel %>"
       data-entry-prefilled="<%= entryHasPrefilledWorkers || entryHasPrefilledTop ? 'true' : 'false' %>"
+      data-entry-visible-limit="<%= entryWorkerDisplayLimit %>"
     >
       <div class="container detail-section__grid">
         <div class="detail-card detail-card--full">
@@ -961,15 +982,15 @@
               >
                 <%= workerEmptyMessage %>
               </p>
-              <% if (entrySnapshot && entrySnapshot.hiddenWorkerCount > 0 && entrySnapshot.moreLink) { %>
+              <% if (entrySnapshot && entryHiddenWorkerCount > 0) { %>
                 <a
                   class="store-entry-workers__more"
-                  href="<%= entrySnapshot.moreLink %>"
+                  href="<%= entryMoreLink %>"
                   data-entry-more-link
                   target="_blank"
                   rel="noopener"
                 >
-                  외 <span data-entry-more-count><%= entrySnapshot.hiddenWorkerCount %></span>명 더 보기
+                  외 <span data-entry-more-count><%= entryHiddenWorkerCount %></span>명 더 보기
                 </a>
               <% } else { %>
                 <a


### PR DESCRIPTION
### Motivation
- Display only up to 15 worker names in the shop detail entry preview and show a consistent “more” link/count when additional workers exist.
- Ensure both server-prefilled HTML and client-side fetched data are normalized to the same 15-name preview behavior and preserve a fallback more-link URL.

### Description
- Server-side: updated `views/shop.ejs` to flatten and trim prefilled `workerRows`, cap visible names at 15, re-chunk into 5-per-row lists, compute an adjusted hidden-worker count, and provide a guaranteed `moreLink` fallback; also expose `data-entry-visible-limit` and include the adjusted `workerRows`/`hiddenWorkerCount` in the prefill JSON.
- Client-side: updated `public/scripts/pages/shop-detail.js` to read `data-entry-visible-limit`, add `getVisibleWorkerSummary` to normalize incoming summary rows to the visible limit, render only the visible rows, and pass the adjusted hidden count to `renderMoreLink`.
- More-link robustness: client-side `renderMoreLink` now prefers the summary `moreLink` but falls back to the existing anchor `href` attribute when the summary `moreLink` is empty.

### Testing
- Compiled the server template with `ejs.compile(require('fs').readFileSync('views/shop.ejs','utf8'))` and it succeeded.
- Performed a syntax check of the client script with `node -c public/scripts/pages/shop-detail.js` and it succeeded.
- Ran `git diff --check` to ensure no whitespace/patch issues and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4546f176e483259c10e69426b4a255)