### PR TITLE
Remove hardcoded ad tracking pixel and shop-to-ad mapping from shop view

### DIFF
--- a/views/shop.ejs
+++ b/views/shop.ejs
@@ -1189,18 +1189,7 @@
     mapScripts.push(`https://dapi.kakao.com/v2/maps/sdk.js?appkey=${encodeURIComponent(kakaoMapAppKey.trim())}&autoload=false&libraries=services`);
   }
   mapScripts.push('/scripts/pages/shop-detail.js');
-  const trackingPixelByShopId = {
-    '강남-달리는토끼-하이퍼블릭': 'au_4_1',
-    '강남-엘리트(사라있네)-하이퍼블릭': 'au_4_2',
-    '강남-디저트(퍼펙트)-하이퍼블릭': 'au_4_3',
-    '강남-유앤미-하이퍼블릭': 'au_4_4',
-    '강남-도파민-하이퍼블릭': 'au_4_5',
-  };
-  const trackingAdCode = trackingPixelByShopId[shop.id];
 %>
-<% if (trackingAdCode) { %>
-  <img src="https://www.adplus.store/api/track?adCode=<%= trackingAdCode %>" alt="" style="width:1px;height:1px;border:0;display:none;" />
-<% } %>
 <%- include('partials/footer', {
   scripts: mapScripts
 }) %>


### PR DESCRIPTION
### Motivation
- Remove the hardcoded shop-to-ad mapping and inline tracking pixel from the shop template to stop injecting external ad tracking and simplify the view.

### Description
- Deleted the `trackingPixelByShopId` mapping and the conditional `<img src="https://www.adplus.store/api/track?...">` injection from `views/shop.ejs` while keeping existing map script inclusion and footer rendering.

### Testing
- Ran `npm test` and the repository's end-to-end smoke tests via `npm run test:e2e` to verify the shop page renders correctly with and without `kakaoMapAppKey`, and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4558ef8c7083259de9eacb17cbf7ee)