### PR TITLE
Fix dynamic sitemap generation and canonical URLs

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,6 +9,7 @@ const shopRoutes = require('./routes/index');
 const entryRoutes = require('./routes/entry');
 const protectedEntryRoutes = require('./routes/protectedEntries');
 const { initializeDataStore } = require('./services/dataStore');
+const { renderSitemap } = require('./controllers/shopController');
 
 initializeDataStore();
 
@@ -18,6 +19,7 @@ const PORT = process.env.PORT || 3000;
 app.set('view engine', 'ejs');
 app.set('views', path.join(__dirname, 'views'));
 
+app.get('/sitemap.xml', renderSitemap);
 app.use(express.static(path.join(__dirname, 'public')));
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));

--- a/controllers/shopController.js
+++ b/controllers/shopController.js
@@ -529,16 +529,47 @@ async function renderShopEntrySummary(req, res, next) {
   }
 }
 
+function escapeXml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function getCanonicalBaseUrl(req) {
+  const configuredUrl = process.env.SITE_URL || 'https://roombbang1st.com';
+
+  return configuredUrl.replace(/\/+$/, '') || `${req.protocol}://${req.get('host')}`;
+}
+
+function buildSitemapUrl({ loc, changefreq, priority }) {
+  return [
+    '  <url>',
+    `    <loc>${escapeXml(loc)}</loc>`,
+    changefreq ? `    <changefreq>${escapeXml(changefreq)}</changefreq>` : null,
+    priority ? `    <priority>${escapeXml(priority)}</priority>` : null,
+    '  </url>',
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
+
 function renderSitemap(req, res) {
   const shops = getShops();
-  const host = `${req.protocol}://${req.get('host')}`;
+  const baseUrl = getCanonicalBaseUrl(req);
   const urls = [
-    `${host}/`,
-    ...shops.map((shop) => `${host}/shops/${encodeURIComponent(shop.id)}`),
+    { loc: `${baseUrl}/`, changefreq: 'daily', priority: '1.0' },
+    ...shops.map((shop) => ({
+      loc: `${baseUrl}/shops/${encodeURIComponent(shop.id)}`,
+      changefreq: 'weekly',
+      priority: '0.8',
+    })),
   ];
 
   const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls
-    .map((url) => `  <url><loc>${url}</loc></url>`)
+    .map(buildSitemapUrl)
     .join('\n')}\n</urlset>`;
 
   res.type('application/xml');


### PR DESCRIPTION
### Motivation
- Ensure `/sitemap.xml` returns an up-to-date sitemap generated from `data/shops.json` instead of the static `public/sitemap.xml` file.
- Use a canonical base URL from `SITE_URL` with a production fallback to avoid incorrect host values in generated links.
- Prevent XML injection and ensure valid sitemap entries when shop IDs or names contain special characters.

### Description
- Register a dedicated route `GET /sitemap.xml` that calls `renderSitemap` before serving static files in `app.js`.
- Replace the previous simple URL list with helper functions `escapeXml`, `getCanonicalBaseUrl`, and `buildSitemapUrl` in `controllers/shopController.js` to produce well-formed XML.
- Build sitemap entries with metadata (`changefreq`, `priority`) for the homepage and each shop detail URL using the canonical base URL from `SITE_URL` (fallback `https://roombbang1st.com`).
- Set the response `Content-Type` to `application/xml` and output the new formatted sitemap XML.

### Testing
- Syntax checks passed with `node -c app.js` and `node -c controllers/shopController.js` (both succeeded).
- Server started successfully with `PORT=4010 node app.js` and the sitemap endpoint returned the new XML when requested with `curl -sS http://127.0.0.1:4010/sitemap.xml` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45741c51748325b3bae54ab26ca3fa)