### PR TITLE
Add `officialHomepage` to shop data and render link on shop page

### DIFF
--- a/data/shops.json
+++ b/data/shops.json
@@ -6,6 +6,7 @@
     "district": "강남구",
     "category": "하이퍼블릭",
     "address": "서울특별시 강남구 역삼동 604-11",
+    "officialHomepage": "https://www.gangnamdaltokki.com",
     "location": {
       "lat": 37.505942,
       "lng": 127.031418

--- a/views/shop.ejs
+++ b/views/shop.ejs
@@ -175,6 +175,14 @@
                 <dt><%= t.shop && t.shop.address ? t.shop.address : 'Address' %></dt>
                 <dd><%= shop.address %></dd>
               </div>
+              <% if (shop.officialHomepage) { %>
+                <div>
+                  <dt><%= t.shop && t.shop.officialHomepage ? t.shop.officialHomepage : '공식 홈페이지' %></dt>
+                  <dd>
+                    <a href="<%= shop.officialHomepage %>" target="_blank" rel="noopener noreferrer"><%= shop.officialHomepage %></a>
+                  </dd>
+                </div>
+              <% } %>
               <div>
                 <dt><%= t.shop && t.shop.hours ? t.shop.hours : 'Hours' %></dt>
                 <dd><%= shop.hours %></dd>


### PR DESCRIPTION
### Motivation
- Enable storing and displaying an official homepage URL for shops so users can navigate to the shop's website directly.
- Improve shop detail page UX by showing a clickable external link when official homepage data is available.

### Description
- Added `officialHomepage` to `data/shops.json` for the sample shop entry `강남-달리는토끼-하이퍼블릭`.
- Updated `views/shop.ejs` to conditionally render the `officialHomepage` block when `shop.officialHomepage` is present.
- The rendered block uses a localized label via `t.shop.officialHomepage` with a fallback of `공식 홈페이지` and outputs an anchor with `target="_blank" rel="noopener noreferrer"`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58b8d2f7ec8325aa23480ca41510d3)