### PR TITLE
Increase 'before-9pm' base pricing for several Gangnam shops

### DIFF
--- a/data/shops.json
+++ b/data/shops.json
@@ -23,7 +23,7 @@
         {
           "id": "before-9pm",
           "label": "오후 9시 이전",
-          "base": 9,
+          "base": 10,
           "highlightLabel": {
             "ko": "9시 전 주대",
             "en": "Before 9 PM Base",
@@ -179,7 +179,7 @@
         {
           "id": "before-9pm",
           "label": "오후 9시 이전",
-          "base": 10,
+          "base": 11,
           "highlightLabel": {
             "ko": "9시 전 주대",
             "en": "Before 9 PM Base",
@@ -336,7 +336,7 @@
         {
           "id": "before-9pm",
           "label": "오후 9시 이전",
-          "base": 10,
+          "base": 11,
           "highlightLabel": {
             "ko": "9시 전 주대",
             "en": "Before 9 PM Base",
@@ -505,7 +505,7 @@
         {
           "id": "before-9pm",
           "label": "오후 9시 이전",
-          "base": 10,
+          "base": 11,
           "highlightLabel": {
             "ko": "9시 전 주대",
             "en": "Before 9 PM Base",
@@ -662,7 +662,7 @@
         {
           "id": "before-9pm",
           "label": "오후 9시 이전",
-          "base": 10,
+          "base": 11,
           "highlightLabel": {
             "ko": "9시 전 주대",
             "en": "Before 9 PM Base",


### PR DESCRIPTION
### Motivation
- Update the stored base rates to reflect new pricing for the `before-9pm` segment across several Gangnam shop listings.

### Description
- Updated `pricingSchedule.segments[0].base` for `강남-달리는토끼-하이퍼블릭` from `9` to `10`.
- Updated `pricingSchedule.segments[0].base` for `강남-엘리트(사라있네)-하이퍼블릭`, `강남-디저트(퍼펙트)-하이퍼블릭`, `강남-유앤미-하이퍼블릭`, and `강남-도파민-하이퍼블릭` from `10` to `11`.
- Preserved all other fields, localized highlight labels, and segment ordering.

### Testing
- Ran JSON validation on `data/shops.json` to ensure the file remains well-formed and schema-compliant and it passed without errors.
- Executed the project's automated test suite via `npm test` and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58bbfc50008325a0ff5abab9e089dd)